### PR TITLE
Make external db vendor unspecific

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Make external db vendor unspecific ([#4])
+
 ## [v0.2.0]
 
 ### Changed
@@ -22,3 +26,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#1]: https://github.com/projectsyn/component-keycloak/pull/1
 [#3]: https://github.com/projectsyn/component-keycloak/pull/3
+[#4]: https://github.com/projectsyn/component-keycloak/pull/4

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -44,14 +44,15 @@ parameters:
       statistics: all
       rules: []
     # Use Bitnami Postgres installed by the Keycloak chart by default
-    postgres:
+    database:
       builtin: true
       external:
         secretname: keycloak-db-credentials
-        address: postgres.example.com
+        vendor: postgres
+        host: postgres.example.com
         port: 5432
         database: keycloak
-        user: keycloak
+        username: keycloak
         password: '?{vaultkv:${customer:name}/${cluster:name}/keycloak/db-password}'
     helm_values:
       replicas: ${keycloak:replicas}
@@ -84,7 +85,7 @@ parameters:
         - secretRef:
             name: ${keycloak:admin:secretname}
         - secretRef:
-            name: ${keycloak:postgres:external:secretname}
+            name: ${keycloak:database:external:secretname}
       serviceAccount:
         labels: ${keycloak:labels}
       ingress:
@@ -110,7 +111,7 @@ parameters:
         labels: ${keycloak:labels}
         rules: ${keycloak:monitoring:rules}
       postgresql:
-        enabled: ${keycloak:postgres:builtin}
+        enabled: ${keycloak:database:builtin}
         image:
           registry: quay.io
         master:

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -19,25 +19,25 @@ local admin_secret = kube.Secret(params.admin.secretname) {
 
 local external_db_secret =
   local isdummysecret =
-    if params.postgres.builtin then
+    if params.database.builtin then
       {
         'commodore.syn.tools/dummy-secret': 'true',
       }
     else
       {};
-  kube.Secret(params.postgres.external.secretname) {
+  kube.Secret(params.database.external.secretname) {
     metadata+: {
       labels+: params.labels + isdummysecret,
     },
     stringData:
-      if !params.postgres.builtin then
+      if !params.database.builtin then
         {
-          DB_VENDOR: 'postgres',
-          DB_ADDR: params.postgres.external.address,
-          DB_PORT: params.postgres.external.port,
-          DB_DATABASE: params.postgres.external.database,
-          DB_USER: params.postgres.external.user,
-          DB_PASSWORD: params.postgres.external.password,
+          DB_VENDOR: params.database.external.vendor,
+          DB_ADDR: params.database.external.host,
+          DB_PORT: params.database.external.port,
+          DB_DATABASE: params.database.external.database,
+          DB_USER: params.database.external.username,
+          DB_PASSWORD: params.database.external.password,
         }
       else {},
   };

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -212,7 +212,7 @@ type:: list
 default:: `[]`
 
 
-== `postgres.builtin`
+== `database.builtin`
 
 [horizontal]
 type:: bool
@@ -221,42 +221,49 @@ default:: `true`
 Use Bitnami Postgres installed by the Keycloak chart by default.
 
 
-== `postgres.external.secretname`
+== `database.external.secretname`
 
 [horizontal]
 type:: string
 default:: `keycloak-db-credentials`
 
 
-== `postgres.external.address`
+== `database.external.vendor`
+
+[horizontal]
+type:: string
+default:: `postgres`
+
+
+== `database.external.host`
 
 [horizontal]
 type:: string
 default:: `postgres.example.com`
 
 
-== `postgres.external.port`
+== `database.external.port`
 
 [horizontal]
 type:: string
 default:: `5432`
 
 
-== `postgres.external.database`
+== `database.external.database`
 
 [horizontal]
 type:: string
 default:: `keycloak`
 
 
-== `postgres.external.user`
+== `database.external.username`
 
 [horizontal]
 type:: string
 default:: `keycloak`
 
 
-== `postgres.external.password`
+== `database.external.password`
 
 [horizontal]
 type:: string


### PR DESCRIPTION
Currently only postgres was supported as an external
database. Adding the vendor variable allow to use
a different supported database as well.

The db variable user has been renamed to username to
make it more clear that it is a string and not an object.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.
