### PR TITLE
Rename keycloak:hostname to keycloak:fqdn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+# Changed
+
+- Rename keycloak:hostname to keycloak:fqdn([#5])
 - Make external db vendor unspecific ([#4])
 
 ## [v0.2.0]
@@ -27,3 +30,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1]: https://github.com/projectsyn/component-keycloak/pull/1
 [#3]: https://github.com/projectsyn/component-keycloak/pull/3
 [#4]: https://github.com/projectsyn/component-keycloak/pull/4
+[#5]: https://github.com/projectsyn/component-keycloak/pull/5

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -4,8 +4,8 @@ parameters:
     release_name: keycloak
     charts:
       keycloak: '9.9.1'
-    # Hostname should be overwritten on the cluster level
-    hostname: keycloak.example.com
+    # FQDN should be overwritten on the cluster level
+    fqdn: keycloak.example.com
     # Keycloak Admin
     admin:
       secretname: keycloak-admin-user
@@ -92,15 +92,15 @@ parameters:
         enabled: ${keycloak:ingress:enabled}
         labels: ${keycloak:labels}
         rules:
-          - host: ${keycloak:hostname}
+          - host: ${keycloak:fqdn}
             paths: ["/"]
         tls:
           - hosts:
-              - ${keycloak:hostname}
+              - ${keycloak:fqdn}
       route:
         enabled: ${keycloak:route:enabled}
         labels: ${keycloak:labels}
-        host: ${keycloak:hostname}
+        host: ${keycloak:fqdn}
       service:
         labels: ${keycloak:labels}
       serviceMonitor:

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -29,14 +29,14 @@ default:: `9.9.1`
 A specific chart version. See the https://kapitan.dev/external_dependencies/#helm-type[kapitan documentation] for more information.
 
 
-== `hostname`
+== `fqdn`
 
 [horizontal]
 type:: string
 default:: `keycloak.example.com`
 
 Defines the FQDN the keycloak ingress or route object is configured.
-Hostname should be overwritten on the cluster level.
+FQDN should be overwritten on the cluster level.
 
 
 == `admin.secretname`


### PR DESCRIPTION
FQDN is more clear that you shouldn't use just the hostname, but
the full qualified domain name used in the ingress or route.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.

