### PR TITLE
Add ingress configuration support for annotations and TLS secretName

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -16,6 +16,8 @@ parameters:
     # Ingress or Route should be enabled on the distribution level
     ingress:
       enabled: false
+      annotations: {}
+      secretName: ${keycloak:fqdn}
     route:
       enabled: false
     # Labels can be extended in the config hierarchy by providing further
@@ -90,6 +92,7 @@ parameters:
         labels: ${keycloak:labels}
       ingress:
         enabled: ${keycloak:ingress:enabled}
+        annotations: ${keycloak:ingress:annotations}
         labels: ${keycloak:labels}
         rules:
           - host: ${keycloak:fqdn}
@@ -97,6 +100,7 @@ parameters:
         tls:
           - hosts:
               - ${keycloak:fqdn}
+            secretName: ${keycloak:ingress:secretName}
       route:
         enabled: ${keycloak:route:enabled}
         labels: ${keycloak:labels}

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -88,6 +88,35 @@ default:: `false`
 Create an ingress object used usually for standard Kubernetes clusters.
 
 
+== `ingress.annotations`
+
+[horizontal]
+type:: dict
+default:: `{}`
+
+Define annotations for the ingress object.
+
+This allows an automatic ACME based certificate creation via cert-manager:
+[source,yaml]
+----
+parameters:
+  keycloak:
+    ingress:
+      annotations:
+        kubernetes.io/tls-acme: 'true'
+        cert-manager.io/cluster-issuer: letsencrypt-production
+----
+
+
+== `ingress.secretName`
+
+[horizontal]
+type:: string
+default:: `${keycloak:fqdn}`
+
+Allows overwriting the default TLS secret name of `${keycloak:fqdn}`.
+
+
 == `route.enabled`
 
 [horizontal]


### PR DESCRIPTION
ACME controllers require having at least one annotation.
The TLS secretName defaults to ${keycloak:fqdn}, but can be
overwritten to be static i.e. keycloak-tls.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [ ] Update the ./CHANGELOG.md.

