### PR TITLE
Bump Keycloak helm chart to 10.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v1.0.0]
 
 ### Added
 
 - Add ingress configuration support for annotations and TLS secretName ([#7])
+
+### Changed
+
+- Bump the keycloak helm chart version from 10.3.1 to 10.3.1 ([#9])
 
 ## [v0.4.0]
 
@@ -46,11 +50,12 @@ Renamed variables:
 
 - Initial open-source implementation ([#1])
 
-[Unreleased]: https://github.com/projectsyn/component-keycloak/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/projectsyn/component-keycloak/compare/v1.0.0...HEAD
 [v0.1.0]: https://github.com/projectsyn/component-keycloak/releases/tag/v0.1.0
 [v0.2.0]: https://github.com/projectsyn/component-keycloak/releases/tag/v0.2.0
 [v0.3.0]: https://github.com/projectsyn/component-keycloak/releases/tag/v0.3.0
 [v0.4.0]: https://github.com/projectsyn/component-keycloak/releases/tag/v0.4.0
+[v1.0.0]: https://github.com/projectsyn/component-keycloak/releases/tag/v1.0.0
 
 [#1]: https://github.com/projectsyn/component-keycloak/pull/1
 [#3]: https://github.com/projectsyn/component-keycloak/pull/3
@@ -58,3 +63,4 @@ Renamed variables:
 [#5]: https://github.com/projectsyn/component-keycloak/pull/5
 [#6]: https://github.com/projectsyn/component-keyclaok/pull/6
 [#7]: https://github.com/projectsyn/component-keyclaok/pull/7
+[#9]: https://github.com/projectsyn/component-keycloak/pull/9

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -3,7 +3,7 @@ parameters:
     namespace: syn-keycloak
     release_name: keycloak
     charts:
-      keycloak: '10.3.0'
+      keycloak: '10.3.1'
     # FQDN should be overwritten on the cluster level
     fqdn: keycloak.example.com
     # Keycloak Admin

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -24,7 +24,7 @@ Usually there is just one deployment and therefore no change is required.
 
 [horizontal]
 type:: helm chart version
-default:: `10.3.0`
+default:: `10.3.1`
 
 A specific chart version. See the https://kapitan.dev/external_dependencies/#helm-type[kapitan documentation] for more information.
 
@@ -317,4 +317,4 @@ default::
 ----
 
 All helm_values are passed to the helm chart.
-This allows to configure all https://github.com/codecentric/helm-charts/tree/keycloak-10.3.0/charts/keycloak#configuration[keycloak helm chart values].
+This allows to configure all https://github.com/codecentric/helm-charts/tree/keycloak-10.3.1/charts/keycloak#configuration[keycloak helm chart values].


### PR DESCRIPTION
Latest currently supported configuration.

See #8 for more information about the incompatibility of the Keycloak helm chart 11.0.0.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.
- [x] Link this PR to related issues.

