### PR TITLE
Allow overwrite the builtin Postgres DB password

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -48,6 +48,8 @@ parameters:
     # Use Bitnami Postgres installed by the Keycloak chart by default
     database:
       builtin: true
+      existingSecret: keycloak-postgresql
+      postgresqlPassword: '?{vaultkv:${customer:name}/${cluster:name}/keycloak/db-password}'
       external:
         secretname: keycloak-db-credentials
         vendor: postgres
@@ -116,6 +118,7 @@ parameters:
         rules: ${keycloak:monitoring:rules}
       postgresql:
         enabled: ${keycloak:database:builtin}
+        existingSecret: ${keycloak:database:existingSecret}
         image:
           registry: quay.io
         master:

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -17,6 +17,15 @@ local admin_secret = kube.Secret(params.admin.secretname) {
   },
 };
 
+local keycloak_postgresql_secret = kube.Secret(params.database.existingSecret) {
+  metadata+: {
+    labels+: params.labels,
+  },
+  stringData: {
+    'postgresql-password': params.database.postgresqlPassword,
+  },
+};
+
 local external_db_secret =
   local isdummysecret =
     if params.database.builtin then
@@ -47,4 +56,5 @@ local external_db_secret =
   '00_namespace': namespace,
   '10_admin_secret': admin_secret,
   '20_external_db_secret': external_db_secret,
+  [if params.database.builtin then '20_keycloak_postgresql_secret']: keycloak_postgresql_secret,
 }

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -272,6 +272,15 @@ It is required to pregenerate the password in Vault.
 vault kv put -cas=0 clusters/kv/${TENANT_ID}/${CLUSTER_ID}/keycloak db-password=$(pwgen -s 32 1)
 ----
 
+To change the password after the initial setup requires the following commands:
+
+[source,bash]
+----
+kubectl -n syn-keycloak exec -ti keycloak-postgresql-0 -- sh
+PGDATABASE="$POSTGRES_DB" PGUSER="$POSTGRES_USER" PGPASSWORD="$POSTGRES_PASSWORD" PGPASSWORD="<old pw>" psql
+ALTER USER keycloak WITH PASSWORD '<new pw>';
+----
+
 
 == `database.external.secretname`
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -250,6 +250,29 @@ default:: `true`
 Use Bitnami Postgres installed by the Keycloak chart by default.
 
 
+== `database.existingSecret`
+
+[horizontal]
+type:: bool
+default:: `keycloak-postgresql`
+
+
+== `database.postgresqlPassword`
+
+[horizontal]
+type:: string
+default:: Vault reference
+
+A Vault reference pointing to the Vault secret containing the Keycloak database user password.
+
+It is required to pregenerate the password in Vault.
+
+[source,bash]
+----
+vault kv put -cas=0 clusters/kv/${TENANT_ID}/${CLUSTER_ID}/keycloak db-password=$(pwgen -s 32 1)
+----
+
+
 == `database.external.secretname`
 
 [horizontal]

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -277,7 +277,7 @@ To change the password after the initial setup requires the following commands:
 [source,bash]
 ----
 kubectl -n syn-keycloak exec -ti keycloak-postgresql-0 -- sh
-PGDATABASE="$POSTGRES_DB" PGUSER="$POSTGRES_USER" PGPASSWORD="$POSTGRES_PASSWORD" PGPASSWORD="<old pw>" psql
+PGDATABASE="$POSTGRES_DB" PGUSER="$POSTGRES_USER" PGPASSWORD="<old pw>" psql
 ALTER USER keycloak WITH PASSWORD '<new pw>';
 ----
 


### PR DESCRIPTION
The default behavior of the codecentric Helm Chart does set a
predefined password, which is insecure.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [ ] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
