### PR TITLE
Encrypt cluster-internal traffic

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -28,6 +28,11 @@ parameters:
       controllerNamespace: ingress-nginx
     route:
       enabled: false
+    acmecertificate:
+      enabled: false
+      name: ${keycloak:fqdn}
+      issuer:
+        name: letsencrypt-production
     # Labels can be extended in the config hierarchy by providing further
     # entries in key `labels`.
     labels:
@@ -129,6 +134,7 @@ parameters:
         enabled: ${keycloak:ingress:enabled}
         annotations: ${keycloak:ingress:annotations}
         labels: ${keycloak:labels}
+        servicePort: https
         rules:
           - host: ${keycloak:fqdn}
             paths: ["/"]

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -68,7 +68,7 @@ parameters:
           group: cert-manager.io
     # Ingress or Route should be enabled on the distribution level
     ingress:
-      enabled: false
+      enabled: true
       controller: nginx
       annotations: ${keycloak:_ingress_annotations:${keycloak:ingress:controller}:${keycloak:tls:termination}:${keycloak:tls:variant}}
       secretName: ingress-tls

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -12,17 +12,17 @@ parameters:
       nginx:
         passthrough:
           certmanager:
-              nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+            nginx.ingress.kubernetes.io/ssl-passthrough: "true"
           vault:
-              nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+            nginx.ingress.kubernetes.io/ssl-passthrough: "true"
         reencrypt:
           certmanager:
-              kubernetes.io/tls-acme: 'true'
-              cert-manager.io/cluster-issuer: ${keycloak:tls:certmanager:issuer:name}
-              nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-              nginx.ingress.kubernetes.io/proxy-ssl-secret: ${keycloak:ingress:tls:secretName}
-              nginx.ingress.kubernetes.io/proxy-ssl-verify: "on"
-              nginx.ingress.kubernetes.io/proxy-ssl-protocols: "TLSv1.2 TLSv1.3"
+            kubernetes.io/tls-acme: 'true'
+            cert-manager.io/cluster-issuer: ${keycloak:tls:certmanager:issuer:name}
+            nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+            nginx.ingress.kubernetes.io/proxy-ssl-secret: ${keycloak:ingress:tls:secretName}
+            nginx.ingress.kubernetes.io/proxy-ssl-verify: "on"
+            nginx.ingress.kubernetes.io/proxy-ssl-protocols: "TLSv1.2 TLSv1.3"
           vault:
             nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
             nginx.ingress.kubernetes.io/proxy-ssl-secret: ${keycloak:ingress:tls:secretName}

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -11,61 +11,27 @@ parameters:
       # and `keycloak.tls.termination`
       none:
         passthrough: ${keycloak:ingress:annotations}
-        edge: ${keycloak:ingress:annotations}
         reencrypt: ${keycloak:ingress:annotations}
       certmanager:
         passthrough:
           nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-        edge:
-          kubernetes.io/tls-acme: 'true'
-          cert-manager.io/cluster-issuer: ${keycloak:tls:certmanager:issuer:name}
         reencrypt:
           nginx.ingress.kubernetes.io/ssl-passthrough: "true"
       vault:
         passthrough: ${keycloak:ingress:annotations}
-        edge: ${keycloak:ingress:annotations}
         reencrypt: ${keycloak:ingress:annotations}
     =_ingress_tls_vault_secret_enabled:
       # This lookup table controls whether create the ingress-tls secret depending on the value of `keycloak.tls.variant`
       # and `keycloak.tls.termination`
       none:
         passthrough: false
-        edge: false
         reencrypt: false
       certmanager:
         passthrough: false
-        edge: false
         reencrypt: false
       vault:
         passthrough: false
-        edge: true
         reencrypt: true
-    =_ingress_service_port:
-      # This lookup table controls whether to configure the port depending on the value of `keycloak.tls.termination`
-      passthrough: https
-      edge: http
-      reencrypt: https
-    =_extravolumes_keycloak_tls:
-      # This lookup table controls whether to inject the keycloak-tls depending on the value of `keycloak.tls.termination`
-      passthrough: |
-        - name: keycloak-tls
-          secret:
-            defaultMode: 420
-            secretName: ${keycloak:tls:secretName}
-      reencrypt: |
-        - name: keycloak-tls
-          secret:
-            defaultMode: 420
-            secretName: ${keycloak:tls:secretName}
-      edge: ''
-    =_extravolumemounts_keycloak_tls:
-      # This lookup table controls whether to use inject the keycloak-tls depending on the value of `keycloak.tls.termination`
-      passthrough: |
-        - mountPath: /etc/x509/https
-          name: keycloak-tls
-          readOnly: true
-      reencrypt: ${keycloak:_extravolumemounts_keycloak_tls:passthrough} # same as passthrough
-      edge: ''
 
     namespace: syn-${_instance}
     release_name: keycloak
@@ -198,12 +164,17 @@ parameters:
             items:
               - key: tls.crt
                 path: tls.crt
-        ${keycloak:_extravolumes_keycloak_tls:${keycloak:tls:termination}}
+        - name: keycloak-tls
+          secret:
+            secretName: ${keycloak:tls:secretName}
+            defaultMode: 420
       extraVolumeMounts: |
         - name: db-certs
           readOnly: true
           mountPath: /opt/jboss/certs
-        ${keycloak:_extravolumemounts_keycloak_tls:${keycloak:tls:termination}}
+        - name: keycloak-tls
+          readOnly: true
+          mountPath: /etc/x509/https
 
       serviceAccount:
         labels: ${keycloak:labels}
@@ -211,7 +182,7 @@ parameters:
         enabled: ${keycloak:ingress:enabled}
         annotations: ${keycloak:_ingress_annotations:${keycloak:tls:variant}:${keycloak:tls:termination}}
         labels: ${keycloak:labels}
-        servicePort: ${keycloak:_ingress_service_port:${keycloak:tls:termination}}
+        servicePort: https
         rules:
           - host: ${keycloak:fqdn}
             paths: ["/"]

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -20,23 +20,14 @@ parameters:
             kubernetes.io/tls-acme: 'true'
             cert-manager.io/cluster-issuer: ${keycloak:tls:certmanager:issuer:name}
             nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-            nginx.ingress.kubernetes.io/proxy-ssl-secret: ${keycloak:ingress:tls:secretName}
+            nginx.ingress.kubernetes.io/proxy-ssl-secret: ${keycloak:tls:secretName}
             nginx.ingress.kubernetes.io/proxy-ssl-verify: "on"
             nginx.ingress.kubernetes.io/proxy-ssl-protocols: "TLSv1.2 TLSv1.3"
           vault:
             nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-            nginx.ingress.kubernetes.io/proxy-ssl-secret: ${keycloak:ingress:tls:secretName}
+            nginx.ingress.kubernetes.io/proxy-ssl-secret: ${keycloak:tls:secretName}
             nginx.ingress.kubernetes.io/proxy-ssl-verify: "on"
             nginx.ingress.kubernetes.io/proxy-ssl-protocols: "TLSv1.2 TLSv1.3"
-    =_ingress_tls_vault_secret_enabled:
-      # This lookup table controls whether create the ingress-tls secret depending on the value of `keycloak.tls.provider`
-      # and `keycloak.tls.termination`
-      certmanager:
-        passthrough: false
-        reencrypt: false
-      vault:
-        passthrough: false
-        reencrypt: true
 
     namespace: syn-${_instance}
     release_name: keycloak
@@ -76,7 +67,6 @@ parameters:
       tls:
         secretName: ${keycloak:ingress:secretName}
         vault:
-          enabled: ${keycloak:_ingress_tls_vault_secret_enabled:${keycloak:tls:provider}:${keycloak:tls:termination}}
           cert: '?{vaultkv:${customer:name}/${cluster:name}/${_instance}/ingress-cert}'
           certKey: '?{vaultkv:${customer:name}/${cluster:name}/${_instance}/ingress-cert-key}'
     route:

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -104,7 +104,7 @@ parameters:
       annotations: {}
       secretName: ingress-tls
       tls:
-        secretName: ${keycloak:secretName}
+        secretName: ${keycloak:ingress:secretName}
         vault:
           enabled: ${keycloak:_ingress_tls_vault_secret_enabled:${keycloak:tls:variant}:${keycloak:tls:termination}}
           cert: '?{vaultkv:${customer:name}/${cluster:name}/${_instance}/ingress-cert}'

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -20,14 +20,8 @@ parameters:
             kubernetes.io/tls-acme: 'true'
             cert-manager.io/cluster-issuer: ${keycloak:tls:certmanager:issuer:name}
             nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-            nginx.ingress.kubernetes.io/proxy-ssl-secret: ${keycloak:tls:secretName}
-            nginx.ingress.kubernetes.io/proxy-ssl-verify: "on"
-            nginx.ingress.kubernetes.io/proxy-ssl-protocols: "TLSv1.2 TLSv1.3"
           vault:
             nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-            nginx.ingress.kubernetes.io/proxy-ssl-secret: ${keycloak:tls:secretName}
-            nginx.ingress.kubernetes.io/proxy-ssl-verify: "on"
-            nginx.ingress.kubernetes.io/proxy-ssl-protocols: "TLSv1.2 TLSv1.3"
 
     namespace: syn-${_instance}
     release_name: keycloak

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -8,7 +8,7 @@ parameters:
       external: false
     =_ingress_annotations:
       # This lookup table controls whether to set specific annotations depending on the value of `keycloak.ingress.controller`,
-      # `keycloak.tls.termination` and `keycloak.tls.variant`
+      # `keycloak.tls.termination` and `keycloak.tls.provider`
       nginx:
         passthrough:
           certmanager:
@@ -29,7 +29,7 @@ parameters:
             nginx.ingress.kubernetes.io/proxy-ssl-verify: "on"
             nginx.ingress.kubernetes.io/proxy-ssl-protocols: "TLSv1.2 TLSv1.3"
     =_ingress_tls_vault_secret_enabled:
-      # This lookup table controls whether create the ingress-tls secret depending on the value of `keycloak.tls.variant`
+      # This lookup table controls whether create the ingress-tls secret depending on the value of `keycloak.tls.provider`
       # and `keycloak.tls.termination`
       certmanager:
         passthrough: false
@@ -53,7 +53,7 @@ parameters:
     replicas: 2
     # TLS configuration
     tls:
-      variant: certmanager
+      provider: certmanager
       termination: reencrypt
       secretName: keycloak-tls
       vault:
@@ -70,12 +70,13 @@ parameters:
     ingress:
       enabled: true
       controller: nginx
-      annotations: ${keycloak:_ingress_annotations:${keycloak:ingress:controller}:${keycloak:tls:termination}:${keycloak:tls:variant}}
+      controllerNamespace: ingress-nginx
+      annotations: ${keycloak:_ingress_annotations:${keycloak:ingress:controller}:${keycloak:tls:termination}:${keycloak:tls:provider}}
       secretName: ingress-tls
       tls:
         secretName: ${keycloak:ingress:secretName}
         vault:
-          enabled: ${keycloak:_ingress_tls_vault_secret_enabled:${keycloak:tls:variant}:${keycloak:tls:termination}}
+          enabled: ${keycloak:_ingress_tls_vault_secret_enabled:${keycloak:tls:provider}:${keycloak:tls:termination}}
           cert: '?{vaultkv:${customer:name}/${cluster:name}/${_instance}/ingress-cert}'
           certKey: '?{vaultkv:${customer:name}/${cluster:name}/${_instance}/ingress-cert-key}'
     route:

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -83,7 +83,7 @@ parameters:
     # TLS configuration
     tls:
       variant: certmanager
-      termination: passthrough
+      termination: reencrypt
       secretName: keycloak-tls
       vault:
         cert: '?{vaultkv:${customer:name}/${cluster:name}/${_instance}/keycloak-cert}'

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -57,9 +57,8 @@ parameters:
       controller: nginx
       controllerNamespace: ingress-nginx
       annotations: ${keycloak:_ingress_annotations:${keycloak:ingress:controller}:${keycloak:tls:termination}:${keycloak:tls:provider}}
-      secretName: ingress-tls
       tls:
-        secretName: ${keycloak:ingress:secretName}
+        secretName: ingress-tls
         vault:
           cert: '?{vaultkv:${customer:name}/${cluster:name}/${_instance}/ingress-cert}'
           certKey: '?{vaultkv:${customer:name}/${cluster:name}/${_instance}/ingress-cert-key}'

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -16,7 +16,8 @@ parameters:
         passthrough:
           nginx.ingress.kubernetes.io/ssl-passthrough: "true"
         reencrypt:
-          nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+          kubernetes.io/tls-acme: 'true'
+          cert-manager.io/cluster-issuer: ${keycloak:tls:certmanager:issuer:name}
       vault:
         passthrough: ${keycloak:ingress:annotations}
         reencrypt: ${keycloak:ingress:annotations}

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -7,20 +7,29 @@ parameters:
       builtin: true
       external: false
     =_ingress_annotations:
-      # This lookup table controls whether to set specific annotations depending on the value of `keycloak.tls.variant`
-      # and `keycloak.tls.termination`
-      none:
+      # This lookup table controls whether to set specific annotations depending on the value of `keycloak.ingress.controller`,
+      # `keycloak.tls.termination` and `keycloak.tls.variant`
+      nginx:
         passthrough:
+          certmanager:
+              nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+          vault:
+              nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+          none:
         reencrypt:
-      certmanager:
-        passthrough:
-          nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-        reencrypt:
-          kubernetes.io/tls-acme: 'true'
-          cert-manager.io/cluster-issuer: ${keycloak:tls:certmanager:issuer:name}
-      vault:
-        passthrough:
-        reencrypt:
+          certmanager:
+              kubernetes.io/tls-acme: 'true'
+              cert-manager.io/cluster-issuer: ${keycloak:tls:certmanager:issuer:name}
+              nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+              nginx.ingress.kubernetes.io/proxy-ssl-secret: ${keycloak:ingress:tls:secretName}
+              nginx.ingress.kubernetes.io/proxy-ssl-verify: "on"
+              nginx.ingress.kubernetes.io/proxy-ssl-protocols: "TLSv1.2 TLSv1.3"
+          vault:
+            nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+            nginx.ingress.kubernetes.io/proxy-ssl-secret: ${keycloak:ingress:tls:secretName}
+            nginx.ingress.kubernetes.io/proxy-ssl-verify: "on"
+            nginx.ingress.kubernetes.io/proxy-ssl-protocols: "TLSv1.2 TLSv1.3"
+          none:
     =_ingress_tls_vault_secret_enabled:
       # This lookup table controls whether create the ingress-tls secret depending on the value of `keycloak.tls.variant`
       # and `keycloak.tls.termination`
@@ -65,7 +74,8 @@ parameters:
     # Ingress or Route should be enabled on the distribution level
     ingress:
       enabled: false
-      annotations: ${keycloak:_ingress_annotations:${keycloak:tls:variant}:${keycloak:tls:termination}}
+      controller: nginx
+      annotations: ${keycloak:_ingress_annotations:${keycloak:ingress:controller}:${keycloak:tls:termination}:${keycloak:tls:variant}}
       secretName: ingress-tls
       tls:
         secretName: ${keycloak:ingress:secretName}

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -6,6 +6,69 @@ parameters:
       # This lookup table controls whether to enable the chart depending on the value of `keycloak.database.provider`
       builtin: true
       external: false
+    =_ingress_annotations:
+      # This lookup table controls whether to set specific annotations depending on the value of `keycloak.tls.variant`
+      # and `keycloak.tls.termination`
+      none:
+        passthrough: ${keycloak:ingress:annotations}
+        edge: ${keycloak:ingress:annotations}
+        reencrypt: ${keycloak:ingress:annotations}
+      certmanager:
+        passthrough:
+          nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+        edge:
+          kubernetes.io/tls-acme: 'true'
+          cert-manager.io/cluster-issuer: ${keycloak:tls:certmanager:issuer:name}
+        reencrypt:
+          nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+      vault:
+        passthrough: ${keycloak:ingress:annotations}
+        edge: ${keycloak:ingress:annotations}
+        reencrypt: ${keycloak:ingress:annotations}
+    =_ingress_tls_vault_secret_enabled:
+      # This lookup table controls whether create the ingress-tls secret depending on the value of `keycloak.tls.variant`
+      # and `keycloak.tls.termination`
+      none:
+        passthrough: false
+        edge: false
+        reencrypt: false
+      certmanager:
+        passthrough: false
+        edge: false
+        reencrypt: false
+      vault:
+        passthrough: false
+        edge: true
+        reencrypt: true
+    =_ingress_service_port:
+      # This lookup table controls whether to configure the port depending on the value of `keycloak.tls.termination`
+      passthrough: https
+      edge: http
+      reencrypt: https
+    =_extravolumes_keycloak_tls:
+      # This lookup table controls whether to inject the keycloak-tls depending on the value of `keycloak.tls.termination`
+      passthrough: |
+        - name: keycloak-tls
+          secret:
+            defaultMode: 420
+            secretName: ${keycloak:tls:secretName}
+      reencrypt: |
+        - name: keycloak-tls
+          secret:
+            defaultMode: 420
+            secretName: ${keycloak:tls:secretName}
+      edge: ''
+    =_extravolumemounts_keycloak_tls:
+      # This lookup table controls whether to use inject the keycloak-tls depending on the value of `keycloak.tls.termination`
+      passthrough: |
+        - mountPath: /etc/x509/https
+          name: keycloak-tls
+          readOnly: true
+      reencrypt: |
+        - mountPath: /etc/x509/https
+          name: keycloak-tls
+          readOnly: true
+      edge: ''
 
     namespace: syn-${_instance}
     release_name: keycloak
@@ -20,19 +83,34 @@ parameters:
       password: '?{vaultkv:${customer:name}/${cluster:name}/${_instance}/admin-password}'
     # Replica count
     replicas: 2
+    # TLS configuration
+    tls:
+      variant: certmanager
+      termination: passthrough
+      secretName: keycloak-tls
+      vault:
+        cert: '?{vaultkv:${customer:name}/${cluster:name}/${_instance}/keycloak-cert}'
+        certKey: '?{vaultkv:${customer:name}/${cluster:name}/${_instance}/keycloak-cert-key}'
+      certmanager:
+        apiVersion: cert-manager.io/v1alpha2
+        certName: ${keycloak:tls:secretName}
+        issuer:
+          name: letsencrypt-production
+          kind: ClusterIssuer
+          group: cert-manager.io
     # Ingress or Route should be enabled on the distribution level
     ingress:
       enabled: false
       annotations: {}
-      secretName: ${keycloak:fqdn}
-      controllerNamespace: ingress-nginx
+      secretName: ingress-tls
+      tls:
+        secretName: ${keycloak:secretName}
+        vault:
+          enabled: ${keycloak:_ingress_tls_vault_secret_enabled:${keycloak:tls:variant}:${keycloak:tls:termination}}
+          cert: '?{vaultkv:${customer:name}/${cluster:name}/${_instance}/ingress-cert}'
+          certKey: '?{vaultkv:${customer:name}/${cluster:name}/${_instance}/ingress-cert-key}'
     route:
       enabled: false
-    acmecertificate:
-      enabled: false
-      name: ${keycloak:fqdn}
-      issuer:
-        name: letsencrypt-production
     # Labels can be extended in the config hierarchy by providing further
     # entries in key `labels`.
     labels:
@@ -123,25 +201,27 @@ parameters:
             items:
               - key: tls.crt
                 path: tls.crt
+        ${keycloak:_extravolumes_keycloak_tls:${keycloak:tls:termination}}
       extraVolumeMounts: |
         - name: db-certs
           readOnly: true
           mountPath: /opt/jboss/certs
+        ${keycloak:_extravolumemounts_keycloak_tls:${keycloak:tls:termination}}
 
       serviceAccount:
         labels: ${keycloak:labels}
       ingress:
         enabled: ${keycloak:ingress:enabled}
-        annotations: ${keycloak:ingress:annotations}
+        annotations: ${keycloak:_ingress_annotations:${keycloak:tls:variant}:${keycloak:tls:termination}}
         labels: ${keycloak:labels}
-        servicePort: https
+        servicePort: ${keycloak:_ingress_service_port:${keycloak:tls:termination}}
         rules:
           - host: ${keycloak:fqdn}
             paths: ["/"]
         tls:
           - hosts:
               - ${keycloak:fqdn}
-            secretName: ${keycloak:ingress:secretName}
+            secretName: ${keycloak:ingress:tls:secretName}
       route:
         enabled: ${keycloak:route:enabled}
         labels: ${keycloak:labels}

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -10,8 +10,8 @@ parameters:
       # This lookup table controls whether to set specific annotations depending on the value of `keycloak.tls.variant`
       # and `keycloak.tls.termination`
       none:
-        passthrough: ${keycloak:ingress:annotations}
-        reencrypt: ${keycloak:ingress:annotations}
+        passthrough:
+        reencrypt:
       certmanager:
         passthrough:
           nginx.ingress.kubernetes.io/ssl-passthrough: "true"
@@ -19,8 +19,8 @@ parameters:
           kubernetes.io/tls-acme: 'true'
           cert-manager.io/cluster-issuer: ${keycloak:tls:certmanager:issuer:name}
       vault:
-        passthrough: ${keycloak:ingress:annotations}
-        reencrypt: ${keycloak:ingress:annotations}
+        passthrough:
+        reencrypt:
     =_ingress_tls_vault_secret_enabled:
       # This lookup table controls whether create the ingress-tls secret depending on the value of `keycloak.tls.variant`
       # and `keycloak.tls.termination`
@@ -65,7 +65,7 @@ parameters:
     # Ingress or Route should be enabled on the distribution level
     ingress:
       enabled: false
-      annotations: {}
+      annotations: ${keycloak:_ingress_annotations:${keycloak:tls:variant}:${keycloak:tls:termination}}
       secretName: ingress-tls
       tls:
         secretName: ${keycloak:ingress:secretName}
@@ -181,7 +181,7 @@ parameters:
         labels: ${keycloak:labels}
       ingress:
         enabled: ${keycloak:ingress:enabled}
-        annotations: ${keycloak:_ingress_annotations:${keycloak:tls:variant}:${keycloak:tls:termination}}
+        annotations: ${keycloak:ingress:annotations}
         labels: ${keycloak:labels}
         servicePort: https
         rules:

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -15,7 +15,6 @@ parameters:
               nginx.ingress.kubernetes.io/ssl-passthrough: "true"
           vault:
               nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-          none:
         reencrypt:
           certmanager:
               kubernetes.io/tls-acme: 'true'
@@ -29,13 +28,9 @@ parameters:
             nginx.ingress.kubernetes.io/proxy-ssl-secret: ${keycloak:ingress:tls:secretName}
             nginx.ingress.kubernetes.io/proxy-ssl-verify: "on"
             nginx.ingress.kubernetes.io/proxy-ssl-protocols: "TLSv1.2 TLSv1.3"
-          none:
     =_ingress_tls_vault_secret_enabled:
       # This lookup table controls whether create the ingress-tls secret depending on the value of `keycloak.tls.variant`
       # and `keycloak.tls.termination`
-      none:
-        passthrough: false
-        reencrypt: false
       certmanager:
         passthrough: false
         reencrypt: false

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -64,10 +64,7 @@ parameters:
         - mountPath: /etc/x509/https
           name: keycloak-tls
           readOnly: true
-      reencrypt: |
-        - mountPath: /etc/x509/https
-          name: keycloak-tls
-          readOnly: true
+      reencrypt: ${keycloak:_extravolumemounts_keycloak_tls:passthrough} # same as passthrough
       edge: ''
 
     namespace: syn-${_instance}

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -73,6 +73,26 @@ local ns_patch =
     }
   );
 
+local keycloak_tls = {
+  apiVersion: 'cert-manager.io/v1alpha2',
+  kind: 'Certificate',
+  metadata: {
+    name: params.acmecertificate.name,
+    labels: params.labels,
+  },
+  spec: {
+    secretName: params.acmecertificate.name,
+    dnsNames: [
+      params.acmecertificate.name,
+    ],
+    issuerRef: {
+      name: params.acmecertificate.issuer.name,
+      kind: 'ClusterIssuer',
+      group: 'cert-manager.io',
+    },
+  },
+};
+
 // Define outputs below
 {
   '00_namespace': namespace,
@@ -80,4 +100,5 @@ local ns_patch =
   '10_admin_secret': admin_secret,
   '11_db_secret': db_secret,
   [if params.database.tls.enabled then '12_db_certs']: db_cert_secret,
+  [if params.acmecertificate.enabled then '13_keycloak_tls']: keycloak_tls,
 }

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -55,7 +55,7 @@ local db_cert_secret = kube.Secret(params.database.tls.certSecretName) {
       }
     else
       {
-        'README.txt': 'Keycloak is configured with DB TLS verification mode "%s", no custom CA cert required' % [params.database.tls.verification],
+        'README.txt': 'Keycloak is configured with DB TLS verification mode "%s", no custom CA cert required' % [ params.database.tls.verification ],
         'tls.crt': '',
       },
 };

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -121,6 +121,6 @@ local ingress_tls = kube.Secret(params.ingress.tls.secretName) {
   '10_admin_secret': admin_secret,
   '11_db_secret': db_secret,
   [if params.database.tls.enabled then '12_db_certs']: db_cert_secret,
-  '13_keycloak_tls': keycloak_tls[params.tls.variant],
+  [if params.ingress.tls.provider == 'vault' then '13_keycloak_certs']: keycloak_tls[params.tls.provider],
   [if params.ingress.tls.vault.enabled then '14_ingress_tls']: ingress_tls,
 }

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -115,6 +115,13 @@ local ingress_tls_secret = kube.Secret(params.ingress.tls.secretName) {
   },
 };
 
+local create_keycloak_cert_secret =
+  params.ingress.enabled && !(params.tls.termination == 'passthrough' && params.tls.provider == 'certmanager');
+local create_ingress_cert_secret =
+  params.ingress.enabled && params.tls.termination == 'reencrypt' && params.tls.provider == 'vault';
+local create_ingress_cert =
+  params.ingress.enabled && params.tls.termination == 'passthrough' && params.tls.provider == 'certmanager';
+
 // Define outputs below
 {
   '00_namespace': namespace,
@@ -122,7 +129,7 @@ local ingress_tls_secret = kube.Secret(params.ingress.tls.secretName) {
   '10_admin_secret': admin_secret,
   '11_db_secret': db_secret,
   [if params.database.tls.enabled then '12_db_certs']: db_cert_secret,
-  [if !(params.tls.termination == 'passthrough' && params.tls.provider == 'certmanager') then '13_keycloak_certs']: keycloak_cert_secret,
-  [if params.tls.termination == 'reencrypt' && params.tls.provider == 'vault' then '14_ingress_certs']: ingress_tls_secret,
-  [if params.tls.termination == 'passthrough' && params.tls.provider == 'certmanager' then '20_le_cert']: cert_manager_cert,
+  [if create_keycloak_cert_secret then '13_keycloak_certs']: keycloak_cert_secret,
+  [if create_ingress_cert_secret then '14_ingress_certs']: ingress_tls_secret,
+  [if create_ingress_cert then '20_le_cert']: cert_manager_cert,
 }

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -121,6 +121,6 @@ local ingress_tls = kube.Secret(params.ingress.tls.secretName) {
   '10_admin_secret': admin_secret,
   '11_db_secret': db_secret,
   [if params.database.tls.enabled then '12_db_certs']: db_cert_secret,
-  [if params.tls.variant != 'none' then '13_keycloak_tls']: keycloak_tls[params.tls.variant],
+  '13_keycloak_tls': keycloak_tls[params.tls.variant],
   [if params.ingress.tls.vault.enabled then '14_ingress_tls']: ingress_tls,
 }

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -55,7 +55,7 @@ local db_cert_secret = kube.Secret(params.database.tls.certSecretName) {
       }
     else
       {
-        'README.txt': 'Keycloak is configured with DB TLS verification mode "%s", no custom CA cert required' % [ params.database.tls.verification ],
+        'README.txt': 'Keycloak is configured with DB TLS verification mode "%s", no custom CA cert required' % [params.database.tls.verification],
         'tls.crt': '',
       },
 };
@@ -101,7 +101,7 @@ local keycloak_tls = {
       'tls.key': params.tls.vault.certKey,
       'tls.crt': params.tls.vault.cert,
     },
-  }
+  },
 };
 
 local ingress_tls = kube.Secret(params.ingress.tls.secretName) {

--- a/docs/modules/ROOT/pages/explanations/default-features.adoc
+++ b/docs/modules/ROOT/pages/explanations/default-features.adoc
@@ -12,7 +12,7 @@ This page gives an overview over the defaults.
 - Enabled network policy for database to protect from unexpected connections
 - Prometheus ServiceMonitor to scrape metrics
 - 2 replicas of Keycloak, with anti-affinity
-- Enabled Ingress
+- Enabled Ingress with re-encryption
 - Configured requests and limits for CPU and memory resources
 
 == Disabled features

--- a/docs/modules/ROOT/pages/how-tos/configure-ingress.adoc
+++ b/docs/modules/ROOT/pages/how-tos/configure-ingress.adoc
@@ -62,14 +62,14 @@ parameters:
       termination: passthrough
 ----
 
-. If you're using CA issued certificates, change the variant:
+. If you're using CA issued certificates, change the provider:
 +
 [source,yaml]
 ----
 parameters:
   keycloak:
     tls:
-      variant: vault
+      provider: vault
 ----
 +
 See xref:how-tos/keycloak-tls.adoc[Setup a TLS certificate for Keycloak] for how to store a certificate in vault.

--- a/docs/modules/ROOT/pages/how-tos/configure-ingress.adoc
+++ b/docs/modules/ROOT/pages/how-tos/configure-ingress.adoc
@@ -1,58 +1,40 @@
 = Configure Keycloak ingress
 
-Incoming network traffic to the Keycloak service is usually routed via an ingress or a route object for OpenShift.
+Incoming network traffic to the Keycloak service is usually routed via an ingress.
 
-== Ingress over an NGINX Controller
+[NOTE]
+====
+Currently, only NGINX ingress controller is supported and tested.
+Others may work as well, but you may need to customize some parameters on your own (or contribute back to the component).
+====
 
-. In a first step the ingress object needs to be enabled
-+
-[source,bash]
-----
-parameters:
-  keycloak:
-    ingress:
-      enabled: true
-----
+See also the following manuals on how to setup the Keycloak encryption:
 
-. Configure the ingress controller (can be skipped as it is the default value)
-+
-[source,bash]
-----
-parameters:
-  keycloak:
-    ingress:
-      controller: nginx
-----
+* https://github.com/keycloak/keycloak-containers/blob/master/server/README.md[Docker image configuration]
 
-. Choose where the TLS session to Keycloak is terminated
+First, choose where the TLS session to Keycloak is terminated.
 
-.. Terminate the TLS session on the ingress and on Keycloak
-+
-[source,bash]
-----
-parameters:
-  keycloak:
-    tls:
-      termination: reencrypt
-----
-+
-This requires Keycloak has a self singed certificate.
-See xref:how-tos/keycloak-tls.adoc[Setup a TLS certificate for Keycloak].
+== Encryption mode: Re-encrypt
 
-.. Terminate the TLS session direct on Keycloak
-+
-[source,bash]
-----
-parameters:
-  keycloak:
-    tls:
-      termination: passthrough
-----
-+
-This requires also that the NGINX Controller is configured to pass through the TLS traffic.
-This is not enabled by default:
-+
-[source,bash]
+In re-encryption mode, the traffic is terminated at the NGINX ingress controller, and then re-encrypted when connecting to Keycloak pods.
+By default, this component will use Let's Encrypt (cert-manager) so that NGINX terminates with valid certificates.
+The connection to Keycloak is using self-signed certificates since Keycloak does not reload certificates when they have changed in the container.
+
+Re-encryption is the default, so there's not much to configure.
+Proceed with xref:how-tos/keycloak-tls.adoc[Setup a TLS certificate for Keycloak].
+
+== Encryption mode: Pass-through
+
+In the pass-through mode, the controller will not terminate the TLS session and instead directly forward the HTTPS traffic to Keycloak.
+The controller needs to support pass-through mode.
+
+[IMPORTANT]
+====
+This mode requires that the NGINX Controller is configured to pass through the TLS traffic.
+This is not enabled by default.
+With https://github.com/projectsyn/component-ingress-nginx[component-ingress-nginx], you can enable it like following:
+
+[source,yaml]
 ----
 parameters:
   ingress_nginx:
@@ -61,24 +43,28 @@ parameters:
         extraArgs:
           enable-ssl-passthrough: true
 ----
+====
+
+[WARNING]
+====
+When using certificates from Let's Encrypt (cert-manager), ensure that you regularly restart Keycloak.
+Otherwise, you may end up serving expired certificates!
+The default Keycloak container image does not reload the certificates when they have changed in the mounted filesystem.
+====
+
+. Terminate the TLS session directly in Keycloak
 +
-. Configure how the certificates being issued
-+
-.. If you plan to use the cert-manager to issue certificates:
-+
-[source,bash]
+[source,yaml]
 ----
 parameters:
   keycloak:
     tls:
-      variant: certmanager
+      termination: passthrough
 ----
+
+. If you're using CA issued certificates, change the variant:
 +
-By default certificates are issued from Let's encrypt.
-+
-.. Manually issued certificates stored in vault:
-+
-[source,bash]
+[source,yaml]
 ----
 parameters:
   keycloak:
@@ -86,4 +72,4 @@ parameters:
       variant: vault
 ----
 +
-See xref:how-tos/keycloak-tls.adoc[Setup a TLS certificate for Keycloak] for how to create a certificate.
+See xref:how-tos/keycloak-tls.adoc[Setup a TLS certificate for Keycloak] for how to store a certificate in vault.

--- a/docs/modules/ROOT/pages/how-tos/configure-ingress.adoc
+++ b/docs/modules/ROOT/pages/how-tos/configure-ingress.adoc
@@ -1,0 +1,89 @@
+= Configure Keycloak ingress
+
+Incoming network traffic to the Keycloak service is usually routed via an ingress or a route object for OpenShift.
+
+== Ingress over an NGINX Controller
+
+. In a first step the ingress object needs to be enabled
++
+[source,bash]
+----
+parameters:
+  keycloak:
+    ingress:
+      enabled: true
+----
+
+. Configure the ingress controller (can be skipped as it is the default value)
++
+[source,bash]
+----
+parameters:
+  keycloak:
+    ingress:
+      controller: nginx
+----
+
+. Choose where the TLS session to Keycloak is terminated
+
+.. Terminate the TLS session on the ingress and on Keycloak
++
+[source,bash]
+----
+parameters:
+  keycloak:
+    tls:
+      termination: reencrypt
+----
++
+This requires Keycloak has a self singed certificate.
+See xref:how-tos/keycloak-tls.adoc[Setup a TLS certificate for Keycloak].
+
+.. Terminate the TLS session direct on Keycloak
++
+[source,bash]
+----
+parameters:
+  keycloak:
+    tls:
+      termination: passthrough
+----
++
+This requires also that the NGINX Controller is configured to pass through the TLS traffic.
+This is not enabled by default:
++
+[source,bash]
+----
+parameters:
+  ingress_nginx:
+    helm_values:
+      controller:
+        extraArgs:
+          enable-ssl-passthrough: true
+----
++
+. Configure how the certificates being issued
++
+.. If you plan to use the cert-manager to issue certificates:
++
+[source,bash]
+----
+parameters:
+  keycloak:
+    tls:
+      variant: certmanager
+----
++
+By default certificates are issued from Let's encrypt.
++
+.. Manually issued certificates stored in vault:
++
+[source,bash]
+----
+parameters:
+  keycloak:
+    tls:
+      variant: vault
+----
++
+See xref:how-tos/keycloak-tls.adoc[Setup a TLS certificate for Keycloak] for how to create a certificate.

--- a/docs/modules/ROOT/pages/how-tos/configure-ingress.adoc
+++ b/docs/modules/ROOT/pages/how-tos/configure-ingress.adoc
@@ -8,7 +8,7 @@ Currently, only NGINX ingress controller is supported and tested.
 Others may work as well, but you may need to customize some parameters on your own (or contribute back to the component).
 ====
 
-See also the following manuals on how to setup the Keycloak encryption:
+See also the following manual on how to setup the Keycloak encryption:
 
 * https://github.com/keycloak/keycloak-containers/blob/master/server/README.md[Docker image configuration]
 

--- a/docs/modules/ROOT/pages/how-tos/keycloak-tls.adoc
+++ b/docs/modules/ROOT/pages/how-tos/keycloak-tls.adoc
@@ -1,12 +1,6 @@
 = Setup a TLS certificate for Keycloak
 
 This guide provides an example how to setup a TLS certificate for Keycloak.
-By default a certificate for Keycloak is required.
-It depends on the ingress configuration, if this certificate - self-signed or CA isused - is configured in vault or issued via the cert-manager.
-
-See the following manuals on how to setup the Keycloak encryption:
-
-* https://hub.docker.com/r/jboss/keycloak/[Docker image configuration]
 
 ====
 Requirements
@@ -17,15 +11,22 @@ Requirements
 * `vault`
 ====
 
-== Using self-signed certificates for the cluster internal connection
-
-. Prepare certificate files when using self-signed certificates
+. Prepare certificate files
 +
+.Self-signed certificates
 [source,bash]
 ----
 # Adjust the lifetime as necessary
 lifetime=3650
 openssl req -x509 -newkey rsa:4096 -nodes -keyout keycloak.key -out keycloak.crt -days ${lifetime} -subj '/CN=keycloak'
+----
++
+.CA issued certificates
+[source,bash]
+----
+# Save the cert and key in these temporary files
+editor keycloak.key
+editor keycloak.crt
 ----
 
 . Store certificate in Vault
@@ -44,19 +45,4 @@ vault kv patch "${parent}/${instance}" keycloak-cert=@keycloak.crt keycloak-cert
 [source,bash]
 ----
 rm keycloak.{key,crt}
-----
-
-== Using CA issued certificates
-
-. Configure TLS verification mode when using CA issued certificates
-+
-. Store certificate in Vault
-+
-[source,bash]
-----
-instance=keycloak
-parent="clusters/kv/${TENANT_ID}/${CLUSTER_ID}"
-
-# Use the 'patch' subcommand to add to existing secret
-vault kv patch "${parent}/${instance}" keycloak-cert=@issued.crt keycloak-cert-key=@issued.key
 ----

--- a/docs/modules/ROOT/pages/how-tos/keycloak-tls.adoc
+++ b/docs/modules/ROOT/pages/how-tos/keycloak-tls.adoc
@@ -1,7 +1,8 @@
 = Setup a TLS certificate for Keycloak
 
 This guide provides an example how to setup a TLS certificate for Keycloak.
-By default a certificate is required. It depends on the ingress configuration, if this certificate is configured in vault (self-signed/CA issued) or issued via the cert-manager.
+By default a certificate for Keycloak is required.
+It depends on the ingress configuration, if this certificate - self-signed or CA isused - is configured in vault or issued via the cert-manager.
 
 See the following manuals on how to setup the Keycloak encryption:
 

--- a/docs/modules/ROOT/pages/how-tos/keycloak-tls.adoc
+++ b/docs/modules/ROOT/pages/how-tos/keycloak-tls.adoc
@@ -1,0 +1,61 @@
+= Setup a TLS certificate for Keycloak
+
+This guide provides an example how to setup a TLS certificate for Keycloak.
+By default a certificate is required. It depends on the ingress configuration, if this certificate is configured in vault (self-signed/CA issued) or issued via the cert-manager.
+
+See the following manuals on how to setup the Keycloak encryption:
+
+* https://hub.docker.com/r/jboss/keycloak/[Docker image configuration]
+
+====
+Requirements
+
+* `commodore`
+* `kubectl`
+* `openssl`
+* `vault`
+====
+
+== Using self-signed certificates for the cluster internal connection
+
+. Prepare certificate files when using self-signed certificates
++
+[source,bash]
+----
+# Adjust the lifetime as necessary
+lifetime=3650
+openssl req -x509 -newkey rsa:4096 -nodes -keyout keycloak.key -out keycloak.crt -days ${lifetime} -subj '/CN=keycloak'
+----
+
+. Store certificate in Vault
++
+[source,bash]
+----
+instance=keycloak
+parent="clusters/kv/${TENANT_ID}/${CLUSTER_ID}"
+
+# Use the 'patch' subcommand to add to existing secret
+vault kv patch "${parent}/${instance}" keycloak-cert=@keycloak.crt keycloak-cert-key=@keycloak.key
+----
+
+. Remove temporary files
++
+[source,bash]
+----
+rm keycloak.{key,crt}
+----
+
+== Using CA issued certificates
+
+. Configure TLS verification mode when using CA issued certificates
++
+. Store certificate in Vault
++
+[source,bash]
+----
+instance=keycloak
+parent="clusters/kv/${TENANT_ID}/${CLUSTER_ID}"
+
+# Use the 'patch' subcommand to add to existing secret
+vault kv patch "${parent}/${instance}" keycloak-cert=@issued.crt keycloak-cert-key=@issued.key
+----

--- a/docs/modules/ROOT/pages/how-tos/multi-instance.adoc
+++ b/docs/modules/ROOT/pages/how-tos/multi-instance.adoc
@@ -40,14 +40,14 @@ Using the `syn-` prefix might not be what you want when using multiple instances
 Use the `namespace` parameter to customize the namespace, but be sure that each instance gets their own namespace.
 ====
 
-. Set secrets
+. Set secrets (don't forget to also xref:how-tos/keycloak-tls.adoc[store certificates for each Keycloak instance])
 +
 [source,bash]
 ----
 parent="clusters/kv/${TENANT_ID}/${CLUSTER_ID}"
 
-vault kv put -cas=0 "${parent}/keycloak-test" admin-password=$(pwgen -s 32 1) db-password=$(pwgen -s 32 1)
-vault kv put -cas=0 "${parent}/keycloak-prod" admin-password=$(pwgen -s 32 1) db-password=<your-external-db-password>
+vault kv put "${parent}/keycloak-test" admin-password=$(pwgen -s 32 1) db-password=$(pwgen -s 32 1)
+vault kv put "${parent}/keycloak-prod" admin-password=$(pwgen -s 32 1) db-password=<your-external-db-password>
 ----
 
 . Compile and push the cluster catalog

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -117,7 +117,6 @@ Defines the termination mode:
 
 * `passthrough` TLS termination happens at Keycloak itself, ingress or route passes the traffic
 * `reencrypt` TLS termination happens at the ingress or route, the traffic is reencrypted
-* `edge` TLS termination is done at the ingress or route, cluster internal traffic is unencrypted
 
 
 == `tls.secretName`
@@ -230,7 +229,7 @@ type:: bool
 default:: `Depends on ${keycloak:tls:variant} ${keycloak:tls:termination}`
 
 Create ingress-tls certificate, if `${keycloak:tls:variant}` is `vault` and the `${keycloak:tls:termination}` is
-`edge` or `reencrypt`.
+`reencrypt`.
 
 
 == `ingress.tls.vault.enabled`

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -151,6 +151,33 @@ default:: `false`
 Create a route object on an OpenShift cluster.
 
 
+== `acmecertificate.enabled`
+
+[horizontal]
+type:: bool
+default:: `false`
+
+Create a certificate object for the cert-manager to issue a certificate for the FQDN `${keycloak:fqdn}`.
+
+
+== `acmecertificate.name`
+
+[horizontal]
+type:: string
+default:: `${keycloak:fqdn}`
+
+Name of the secret the cert-manager saves the issued certificate to.
+
+
+== `acmecertificate.issuer.name`
+
+[horizontal]
+type:: string
+default:: `letsencrypt-production`
+
+Define the issuer name. This is usualy `letsencrypt-production` or `letsencrypt-staging`.
+
+
 == `labels."app.kubernetes.io/name"`
 
 [horizontal]

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -174,6 +174,17 @@ default:: `false`
 Create an ingress object used usually for standard Kubernetes clusters.
 
 
+== `ingress.controller`
+
+[horizontal]
+type:: string
+default:: `nginx`
+
+Does define the used ingress controller on the cluster side.
+
+Defaults to `nginx` and this is currently also the only valid option.
+
+
 == `ingress.annotations`
 
 [horizontal]

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -94,6 +94,78 @@ The Keycloak pod replicas.
 Usualy two for the redundancy during the maintenance.
 
 
+== `tls.variant`
+
+[horizontal]
+type:: string
+default:: `certmanager`
+
+Defines the variant how TLS certificates are deployed:
+
+* `none` for no TLS certificates
+* `certmanager` for certificates issued via cert-manager
+* `vault` for certificates stored in Vault
+
+
+== `tls.termination`
+
+[horizontal]
+type:: string
+default:: `passthrough`
+
+Defines the termination mode:
+
+* `passthrough` TLS termination happens at Keycloak itself, ingress or route passes the traffic
+* `reencrypt` TLS termination happens at the ingress or route, the traffic is reencrypted
+* `edge` TLS termination is done at the ingress or route, cluster internal traffic is unencrypted
+
+
+== `tls.secretName`
+
+[horizontal]
+type:: string
+default:: `passthrough`
+
+
+== `tls.vault.cert`
+
+[horizontal]
+type:: string
+default:: Vault reference
+
+
+== `tls.vault.cert`
+
+[horizontal]
+type:: String
+default:: Vault reference
+
+
+== `tls.certmanager.issuer.name`
+
+[horizontal]
+type:: string
+default:: `letsencrypt-production`
+
+Define the issuer name. This is usualy `letsencrypt-production` or `letsencrypt-staging`.
+
+
+== `tls.certmanager.issuer.kind`
+
+[horizontal]
+type:: string
+default:: `ClusterIssuer`
+
+Define the issuer kind. Can be `ClusterIssuer` or `Issuer`.
+
+
+== `tls.certmanager.issuer.group`
+
+[horizontal]
+type:: string
+default:: `cert-manager.io`
+
+
 == `ingress.enabled`
 
 [horizontal]
@@ -127,9 +199,9 @@ parameters:
 
 [horizontal]
 type:: string
-default:: `${keycloak:fqdn}`
+default:: `ingress-tls`
 
-Allows overwriting the default TLS secret name of `${keycloak:fqdn}`.
+Deprecated see `ingress.tls.secretName`.
 
 
 == `ingress.controllerNamespace`
@@ -142,6 +214,46 @@ The namespace where the ingress controller is running.
 This is only relevant when enabling the network policy with `helm_values.networkPolicy.enabled`.
 
 
+== `ingress.tls.secretName`
+
+[horizontal]
+type:: string
+default:: `ingress-tls`
+
+Allows overwriting the default TLS secret name of `ingress-tls`.
+
+
+== `ingress.tls.vault.enabled`
+
+[horizontal]
+type:: bool
+default:: `Depends on ${keycloak:tls:variant} ${keycloak:tls:termination}`
+
+Create ingress-tls certificate, if `${keycloak:tls:variant}` is `vault` and the `${keycloak:tls:termination}` is
+`edge` or `reencrypt`.
+
+
+== `ingress.tls.vault.enabled`
+
+[horizontal]
+type:: bool
+default:: `Depends on ${keycloak:tls:variant} ${keycloak:tls:termination}`
+
+
+== `ingress.tls.vault.cert`
+
+[horizontal]
+type:: string
+default:: Vault reference
+
+
+== `ingress.tls.vault.certKey`
+
+[horizontal]
+type:: string
+default:: Vault reference
+
+
 == `route.enabled`
 
 [horizontal]
@@ -149,33 +261,6 @@ type:: bool
 default:: `false`
 
 Create a route object on an OpenShift cluster.
-
-
-== `acmecertificate.enabled`
-
-[horizontal]
-type:: bool
-default:: `false`
-
-Create a certificate object for the cert-manager to issue a certificate for the FQDN `${keycloak:fqdn}`.
-
-
-== `acmecertificate.name`
-
-[horizontal]
-type:: string
-default:: `${keycloak:fqdn}`
-
-Name of the secret the cert-manager saves the issued certificate to.
-
-
-== `acmecertificate.issuer.name`
-
-[horizontal]
-type:: string
-default:: `letsencrypt-production`
-
-Define the issuer name. This is usualy `letsencrypt-production` or `letsencrypt-staging`.
 
 
 == `labels."app.kubernetes.io/name"`

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -145,8 +145,8 @@ default:: `?{vaultkv:${customer:name}/${cluster:name}/${_instance}/keycloak-cert
 type:: string
 default:: `letsencrypt-production`
 
-Define the issuer name.
-This is usually `letsencrypt-production` or `letsencrypt-staging`.
+Define the cert-manager issuer name.
+If cert-manager is managed by https://github.com/projectsyn/component-cert-manager/[component cert-manager] with the default configuration, this is one of `letsencrypt-production` or `letsencrypt-staging`.
 
 
 == `tls.certmanager.issuer.kind`
@@ -192,9 +192,9 @@ Defaults to `nginx` and this is currently also the only supported option.
 type:: dict
 default:: `{}`
 
-Default takes predefined annotations configured depending on `tls.provider` and `tls.termination`.
+By default, a set of annotations is configured depending on `tls.provider` and `tls.termination`.
 
-The default can always be replaced by an own definition of annotations.
+The default annotations can extended with custom annotations as required.
 
 An example shows how to allow an automatic ACME based certificate creation via cert-manager:
 [source,yaml]

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -94,13 +94,13 @@ The Keycloak pod replicas.
 Usualy two for the redundancy during the maintenance.
 
 
-== `tls.variant`
+== `tls.provider`
 
 [horizontal]
 type:: string
 default:: `certmanager`
 
-Defines the variant how TLS certificates are deployed:
+Defines how TLS certificates are provisioned:
 
 * `certmanager` for certificates issued via cert-manager
 * `vault` for certificates stored in Vault
@@ -190,7 +190,7 @@ Defaults to `nginx` and this is currently also the only valid option.
 type:: dict
 default:: `{}`
 
-Default takes predefined annotations configured from `tls.variant` and `tls.termination`.
+Default takes predefined annotations configured from `tls.provider` and `tls.termination`.
 
 The default can always be replaced by an own definition of annotations.
 
@@ -238,9 +238,9 @@ Allows overwriting the default TLS secret name of `ingress-tls`.
 
 [horizontal]
 type:: bool
-default:: `Depends on ${keycloak:tls:variant} ${keycloak:tls:termination}`
+default:: `Depends on ${keycloak:tls:provider} ${keycloak:tls:termination}`
 
-Create ingress-tls certificate, if `${keycloak:tls:variant}` is `vault` and the `${keycloak:tls:termination}` is
+Create ingress-tls certificate, if `${keycloak:tls:provider}` is `vault` and the `${keycloak:tls:termination}` is
 `reencrypt`.
 
 
@@ -248,7 +248,7 @@ Create ingress-tls certificate, if `${keycloak:tls:variant}` is `vault` and the 
 
 [horizontal]
 type:: bool
-default:: `Depends on ${keycloak:tls:variant} ${keycloak:tls:termination}`
+default:: `Depends on ${keycloak:tls:provider} ${keycloak:tls:termination}`
 
 
 == `ingress.tls.vault.cert`

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -102,7 +102,6 @@ default:: `certmanager`
 
 Defines the variant how TLS certificates are deployed:
 
-* `none` for no TLS certificates
 * `certmanager` for certificates issued via cert-manager
 * `vault` for certificates stored in Vault
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -102,27 +102,27 @@ default:: `certmanager`
 
 Defines how TLS certificates are provisioned:
 
-* `certmanager` for certificates issued via cert-manager
-* `vault` for certificates stored in Vault
+* `certmanager` for certificates issued via cert-manager.
+* `vault` for certificates stored in Vault.
 
 
 == `tls.termination`
 
 [horizontal]
 type:: string
-default:: `passthrough`
+default:: `reencrypt`
 
 Defines the termination mode:
 
-* `passthrough` TLS termination happens at Keycloak itself, ingress or route passes the traffic
-* `reencrypt` TLS termination happens at the ingress or route, the traffic is reencrypted
+* `reencrypt` TLS termination happens at the ingress or route, the traffic is re-encrypted.
+* `passthrough` TLS termination happens at Keycloak itself, ingress or route passes the traffic.
 
 
 == `tls.secretName`
 
 [horizontal]
 type:: string
-default:: `passthrough`
+default:: `keycloak-tls`
 
 
 == `tls.vault.cert`
@@ -145,7 +145,8 @@ default:: Vault reference
 type:: string
 default:: `letsencrypt-production`
 
-Define the issuer name. This is usualy `letsencrypt-production` or `letsencrypt-staging`.
+Define the issuer name.
+This is usually `letsencrypt-production` or `letsencrypt-staging`.
 
 
 == `tls.certmanager.issuer.kind`
@@ -154,7 +155,8 @@ Define the issuer name. This is usualy `letsencrypt-production` or `letsencrypt-
 type:: string
 default:: `ClusterIssuer`
 
-Define the issuer kind. Can be `ClusterIssuer` or `Issuer`.
+Define the issuer kind.
+Can be `ClusterIssuer` or `Issuer`.
 
 
 == `tls.certmanager.issuer.group`
@@ -168,7 +170,7 @@ default:: `cert-manager.io`
 
 [horizontal]
 type:: bool
-default:: `false`
+default:: `true`
 
 Create an ingress object used usually for standard Kubernetes clusters.
 
@@ -181,7 +183,7 @@ default:: `nginx`
 
 Does define the used ingress controller on the cluster side.
 
-Defaults to `nginx` and this is currently also the only valid option.
+Defaults to `nginx` and this is currently also the only supported option.
 
 
 == `ingress.annotations`
@@ -190,7 +192,7 @@ Defaults to `nginx` and this is currently also the only valid option.
 type:: dict
 default:: `{}`
 
-Default takes predefined annotations configured from `tls.provider` and `tls.termination`.
+Default takes predefined annotations configured depending on `tls.provider` and `tls.termination`.
 
 The default can always be replaced by an own definition of annotations.
 
@@ -204,15 +206,6 @@ parameters:
         kubernetes.io/tls-acme: 'true'
         cert-manager.io/cluster-issuer: letsencrypt-production
 ----
-
-
-== `ingress.secretName`
-
-[horizontal]
-type:: string
-default:: `ingress-tls`
-
-Deprecated see `ingress.tls.secretName`.
 
 
 == `ingress.controllerNamespace`
@@ -231,24 +224,7 @@ This is only relevant when enabling the network policy with `helm_values.network
 type:: string
 default:: `ingress-tls`
 
-Allows overwriting the default TLS secret name of `ingress-tls`.
-
-
-== `ingress.tls.vault.enabled`
-
-[horizontal]
-type:: bool
-default:: `Depends on ${keycloak:tls:provider} ${keycloak:tls:termination}`
-
-Create ingress-tls certificate, if `${keycloak:tls:provider}` is `vault` and the `${keycloak:tls:termination}` is
-`reencrypt`.
-
-
-== `ingress.tls.vault.enabled`
-
-[horizontal]
-type:: bool
-default:: `Depends on ${keycloak:tls:provider} ${keycloak:tls:termination}`
+Allows overwriting the default secret name where the ingress controller looks for the certificates.
 
 
 == `ingress.tls.vault.cert`

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -180,9 +180,11 @@ Create an ingress object used usually for standard Kubernetes clusters.
 type:: dict
 default:: `{}`
 
-Define annotations for the ingress object.
+Default takes predefined annotations configured from `tls.variant` and `tls.termination`.
 
-This allows an automatic ACME based certificate creation via cert-manager:
+The default can always be replaced by an own definition of annotations.
+
+An example shows how to allow an automatic ACME based certificate creation via cert-manager:
 [source,yaml]
 ----
 parameters:

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -129,14 +129,14 @@ default:: `keycloak-tls`
 
 [horizontal]
 type:: string
-default:: Vault reference
+default:: `?{vaultkv:${customer:name}/${cluster:name}/${_instance}/keycloak-cert}`
 
 
 == `tls.vault.cert`
 
 [horizontal]
 type:: String
-default:: Vault reference
+default:: `?{vaultkv:${customer:name}/${cluster:name}/${_instance}/keycloak-cert-key}`
 
 
 == `tls.certmanager.issuer.name`
@@ -231,14 +231,14 @@ Allows overwriting the default secret name where the ingress controller looks fo
 
 [horizontal]
 type:: string
-default:: Vault reference
+default:: `?{vaultkv:${customer:name}/${cluster:name}/${_instance}/ingress-cert}`
 
 
 == `ingress.tls.vault.certKey`
 
 [horizontal]
 type:: string
-default:: Vault reference
+default:: `?{vaultkv:${customer:name}/${cluster:name}/${_instance}/ingress-cert-key}`
 
 
 == `route.enabled`
@@ -400,7 +400,7 @@ For example: `sslmode=verify-ca&sslrootcert=/opt/jboss/certs/tls.crt&mycustompar
 
 [horizontal]
 type:: string
-default:: Vault reference
+default:: `?{vaultkv:${customer:name}/${cluster:name}/${_instance}/db-password}`
 
 A Vault reference pointing to the Vault secret containing the Keycloak database password.
 
@@ -477,7 +477,7 @@ default:: `keycloak-postgresql-tls`
 
 [horizontal]
 type:: string
-default:: Vault reference
+default:: `?{vaultkv:${customer:name}/${cluster:name}/${_instance}/server-cert}`
 
 See xref:how-tos/db-tls.adoc[Encrypt database connection] to install Keycloak with encryption.
 
@@ -486,7 +486,7 @@ See xref:how-tos/db-tls.adoc[Encrypt database connection] to install Keycloak wi
 
 [horizontal]
 type:: string
-default:: Vault reference
+default:: `?{vaultkv:${customer:name}/${cluster:name}/${_instance}/server-cert-key}`
 
 See xref:how-tos/db-tls.adoc[Encrypt database connection] to install Keycloak with encryption.
 

--- a/docs/modules/ROOT/pages/tutorials/installation.adoc
+++ b/docs/modules/ROOT/pages/tutorials/installation.adoc
@@ -16,7 +16,15 @@ When using component instantiation, you can choose the provider individually per
 Encrypting the connection to the database adds more security at the cost of some TLS overhead.
 Supported are self-signed certificates by default, though Let's Encrypt and other commercial certificates can be used for the external database provider.
 +
-* xref:how-tos/tls.adoc[Encrypt database connection]
+* xref:how-tos/db-tls.adoc[Encrypt database connection]
+
+. Decide on encryption mode between ingress controller and Keycloak
++
+By default the traffic between ingress controller and Keycloak pods is re-encrypted.
+You can also choose to passthrough the traffic directly to Keycloak on supported ingress controllers.
++
+.. xref:how-tos/configure-ingress.adoc[Configure ingress]
+.. xref:how-tos/keycloak-tls.adoc[Setup certificates for Keycloak]
 
 . Decide whether you need multiple instances
 +

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -9,6 +9,7 @@
 * xref:how-tos/multi-instance.adoc[Deploy multiple instances]
 * xref:how-tos/db-tls.adoc[Encrypt database connection]
 * xref:how-tos/keycloak-tls.adoc[Setup a TLS certificate for Keycloak]
+* xref:how-tos/configure-ingress.adoc[Configure Keycloak ingress]
 * xref:how-tos/change-passwords.adoc[Change passwords]
 * xref:how-tos/upgrade-1.x-to-2.x.adoc[Upgrade 1.x to 2.x]
 * xref:how-tos/upgrade-2.x-to-3.x.adoc[Upgrade 2.x to 3.x]

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -8,6 +8,7 @@
 * xref:how-tos/use-external-db.adoc[Use external database]
 * xref:how-tos/multi-instance.adoc[Deploy multiple instances]
 * xref:how-tos/db-tls.adoc[Encrypt database connection]
+* xref:how-tos/keycloak-tls.adoc[Setup a TLS certificate for Keycloak]
 * xref:how-tos/change-passwords.adoc[Change passwords]
 * xref:how-tos/upgrade-1.x-to-2.x.adoc[Upgrade 1.x to 2.x]
 * xref:how-tos/upgrade-2.x-to-3.x.adoc[Upgrade 2.x to 3.x]

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -13,6 +13,7 @@
 * xref:how-tos/change-passwords.adoc[Change passwords]
 * xref:how-tos/upgrade-1.x-to-2.x.adoc[Upgrade 1.x to 2.x]
 * xref:how-tos/upgrade-2.x-to-3.x.adoc[Upgrade 2.x to 3.x]
+* xref:how-tos/upgrade-3.x-to-4.x.adoc[Upgrade 3.x to 4.x]
 * xref:how-tos/pin-versions.adoc[Pin versions]
 
 .Explanations

--- a/tests/external.yml
+++ b/tests/external.yml
@@ -15,3 +15,6 @@ parameters:
       jdbcParams: sslmode=verify-ca&sslrootcert=/etc/ssl/certs/ca-bundle.crt
       tls:
         verification: verify
+    tls:
+      provider: vault
+      termination: passthrough


### PR DESCRIPTION
This increases the security as the cluster internal traffic is encrypted
as well.

The secrets and cert-manager-certificate maintained by ArgoCD are created based whether `termination` and certificate `provider`.

| Combination                                        | Keycloak TLS Secret<br>(keycloak-tls) | Ingress TLS Secret<br>(ingress-tls) | Ingress Certificate (cert-manager) |
|----------------------------------------------------|---------------------------------------|-------------------------------------|------------------------------------|
| Termination: reencrypt,<br>Provider: certmanager   | yes                                   | (generated by cert-manager)         | (via annotation on ingress)        |
| Termination: reencrypt,<br>Provider: vault         | yes                                   | yes                                 |                                    |
| Termination: passthrough,<br>Provider: certmanager | (generated by cert-manager)           |                                     | yes                                |
| Termination: passthrough,<br>Provider: vault       | yes                                   |                                     |                                    |

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
