### PR TITLE
Disable network policy for Keycloak by default

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -25,6 +25,7 @@ parameters:
       enabled: false
       annotations: {}
       secretName: ${keycloak:fqdn}
+      controllerNamespace: ingress-nginx
     route:
       enabled: false
     # Labels can be extended in the config hierarchy by providing further
@@ -141,6 +142,14 @@ parameters:
         host: ${keycloak:fqdn}
       networkPolicy:
         enabled: true
+        # Note: On Syn-managed OpenShift4 clusters there should be already NetworkPolicies that allow traffic from Ingress controller out-of-the-box.
+        extraFrom:
+          - podSelector:
+              matchLabels:
+                app: ingress-nginx
+            namespaceSelector:
+              matchLabels:
+                name: ${keycloak:ingress:controllerNamespace}
       service:
         # Workaround until https://github.com/codecentric/helm-charts/pull/432 is solved
         httpPort: 8080

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -141,7 +141,8 @@ parameters:
         labels: ${keycloak:labels}
         host: ${keycloak:fqdn}
       networkPolicy:
-        enabled: true
+        # Note: Do not enable when using ingress controller with hostNetwork=true.
+        enabled: false
         # Note: On Syn-managed OpenShift4 clusters there should be already NetworkPolicies that allow traffic from Ingress controller out-of-the-box.
         extraFrom:
           - podSelector:

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -142,6 +142,8 @@ parameters:
       networkPolicy:
         enabled: true
       service:
+        # Workaround until https://github.com/codecentric/helm-charts/pull/432 is solved
+        httpPort: 8080
         labels: ${keycloak:labels}
       serviceMonitor:
         enabled: ${keycloak:monitoring:enabled}

--- a/docs/modules/ROOT/pages/explanations/default-features.adoc
+++ b/docs/modules/ROOT/pages/explanations/default-features.adoc
@@ -9,8 +9,26 @@ This page gives an overview over the defaults.
 
 - Installs single-node PostgreSQL as the built-in database provider
 - Encrypted connection to database
-- Enabled network policies to protect from unexpected connections
+- Enabled network policy for database to protect from unexpected connections
 - Prometheus ServiceMonitor to scrape metrics
 - 2 replicas of Keycloak, with anti-affinity
 - Enabled Ingress
 - Configured requests and limits for CPU and memory resources
+
+== Disabled features
+
+=== Network policy for Keycloak
+
+This component also supports installing a network policy to better control which pods can connect to Keycloak.
+The network policy is disabled by default since it depends on the cluster setup whether they work correctly or not.
+
+[WARNING]
+====
+Do not enable network policy if your cluster has an ingress controller installed where its pods are using the host network (`hostNetwork: true)`.
+At least with the Calico network plugin, network policy label selectors targeting the host networked ingress pods do not work.
+We recommend to keep this feature disabled in that case.
+====
+
+However, if you don't need an ingress controller to connect to Keycloak, or using an ingress controller that doesn't use host network, network policy might be enabled.
+
+NOTE: The network policy for the built-in database is not affected and is enabled by default (if using the built-in database).

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -132,6 +132,16 @@ default:: `${keycloak:fqdn}`
 Allows overwriting the default TLS secret name of `${keycloak:fqdn}`.
 
 
+== `ingress.controllerNamespace`
+
+[horizontal]
+type:: string
+default:: `ingress-nginx`
+
+The namespace where the ingress controller is running.
+This is only relevant when enabling the network policy with `helm_values.networkPolicy.enabled`.
+
+
 == `route.enabled`
 
 [horizontal]


### PR DESCRIPTION
* Ensures ingress-controller can connect to Keycloak (provided they are not using host network)
* Adds new parameter `ingress.controllerNamespace`.
* Disable network policy for Keycloak.
* Add a warning in the feature explanation page that users should not blindingly activate netpol for Keycloak when also Ingress.
* Works around a wrong http port in the network policy for Keycloak (upstream PR https://github.com/codecentric/helm-charts/pull/432).

Fixes #19 
Regression from #17 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
