### PR TITLE
Document & test multiple themes

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -17,7 +17,7 @@ parameters:
             nginx.ingress.kubernetes.io/ssl-passthrough: "true"
         reencrypt:
           certmanager:
-            kubernetes.io/tls-acme: 'true'
+            kubernetes.io/tls-acme: "true"
             cert-manager.io/cluster-issuer: ${keycloak:tls:certmanager:issuer:name}
             nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
           vault:
@@ -26,14 +26,14 @@ parameters:
     namespace: syn-${_instance}
     release_name: keycloak
     charts:
-      keycloak: '10.3.1'
+      keycloak: "10.3.1"
     # FQDN should be overwritten on the cluster level
     fqdn: keycloak.example.com
     # Keycloak Admin
     admin:
       secretname: keycloak-admin-user
       username: admin
-      password: '?{vaultkv:${customer:name}/${cluster:name}/${_instance}/admin-password}'
+      password: "?{vaultkv:${customer:name}/${cluster:name}/${_instance}/admin-password}"
     # Replica count
     replicas: 2
     # TLS configuration
@@ -42,8 +42,8 @@ parameters:
       termination: reencrypt
       secretName: keycloak-tls
       vault:
-        cert: '?{vaultkv:${customer:name}/${cluster:name}/${_instance}/keycloak-cert}'
-        certKey: '?{vaultkv:${customer:name}/${cluster:name}/${_instance}/keycloak-cert-key}'
+        cert: "?{vaultkv:${customer:name}/${cluster:name}/${_instance}/keycloak-cert}"
+        certKey: "?{vaultkv:${customer:name}/${cluster:name}/${_instance}/keycloak-cert-key}"
       certmanager:
         apiVersion: cert-manager.io/v1
         certName: ${keycloak:tls:secretName}
@@ -60,8 +60,8 @@ parameters:
       tls:
         secretName: ingress-tls
         vault:
-          cert: '?{vaultkv:${customer:name}/${cluster:name}/${_instance}/ingress-cert}'
-          certKey: '?{vaultkv:${customer:name}/${cluster:name}/${_instance}/ingress-cert-key}'
+          cert: "?{vaultkv:${customer:name}/${cluster:name}/${_instance}/ingress-cert}"
+          certKey: "?{vaultkv:${customer:name}/${cluster:name}/${_instance}/ingress-cert-key}"
     route:
       enabled: false
     # Labels can be extended in the config hierarchy by providing further
@@ -103,7 +103,7 @@ parameters:
       provider: builtin
 
       secretname: keycloak-postgresql
-      password: '?{vaultkv:${customer:name}/${cluster:name}/${_instance}/db-password}'
+      password: "?{vaultkv:${customer:name}/${cluster:name}/${_instance}/db-password}"
       database: keycloak
       username: keycloak
       jdbcParams: sslmode=verify-ca&sslrootcert=/opt/jboss/certs/tls.crt
@@ -112,8 +112,8 @@ parameters:
         enabled: true
         verification: selfsigned
         certSecretName: keycloak-postgresql-tls
-        serverCert: '?{vaultkv:${customer:name}/${cluster:name}/${_instance}/server-cert}'
-        serverCertKey: '?{vaultkv:${customer:name}/${cluster:name}/${_instance}/server-cert-key}'
+        serverCert: "?{vaultkv:${customer:name}/${cluster:name}/${_instance}/server-cert}"
+        serverCertKey: "?{vaultkv:${customer:name}/${cluster:name}/${_instance}/server-cert-key}"
 
       # Used when `provider=external`
       external:
@@ -126,12 +126,12 @@ parameters:
       keepjobs: 3
       repo:
         secretName: k8up-repo
-        password: '?{vaultkv:${cluster:tenant}/${cluster:name}/keycloak/k8up-repo-password}'
+        password: "?{vaultkv:${cluster:tenant}/${cluster:name}/keycloak/k8up-repo-password}"
       s3:
         secretName: k8up-s3-credentials
         bucket: k8up-${cluster:name}-syn-keycloak
-        accessKey: '?{vaultkv:${cluster:tenant}/${cluster:name}/keycloak/k8up-s3-accesskey}'
-        secretKey: '?{vaultkv:${cluster:tenant}/${cluster:name}/keycloak/k8up-s3-secretkey}'
+        accessKey: "?{vaultkv:${cluster:tenant}/${cluster:name}/keycloak/k8up-s3-accesskey}"
+        secretKey: "?{vaultkv:${cluster:tenant}/${cluster:name}/keycloak/k8up-s3-secretkey}"
 
     helm_values:
       image:

--- a/class/keycloak.yml
+++ b/class/keycloak.yml
@@ -26,7 +26,7 @@ parameters:
           - keycloak/helmcharts/keycloak/${keycloak:charts:keycloak}/
         helm_params:
           release_name: ${keycloak:release_name}
-          namespace: '${keycloak:namespace}'
+          namespace: "${keycloak:namespace}"
         helm_values: ${keycloak:helm_values}
   commodore:
     postprocess:

--- a/docs/modules/ROOT/pages/how-tos/custom-theme.adoc
+++ b/docs/modules/ROOT/pages/how-tos/custom-theme.adoc
@@ -1,11 +1,11 @@
-= Configure custom theme
+= Configure custom themes
 
 Keycloak provides theme support for web pages and emails.
 This allows customizing the look and feel of end-user facing pages so they can be integrated with your applications.
 
-The intended approach to configure a custom theme is to bundle the theme in a container image and copy it to the correct location as an init container.
+The intended approach to configure a custom themes is to bundle the themes in a container image and copy it to the correct location as an init container.
 
-== Creating custom theme
+== Creating custom themes
 
 A theme can provide one or more types to customize different aspects of Keycloak.
 A theme consists of: HTML templates, images, message bundles, stylesheets, scripts and theme properties.
@@ -29,7 +29,7 @@ USER 1001:0
 
 
 
-== Deploying custom theme
+== Deploying custom themes
 
 With the theme accessible in a container image we can deploy it using an init container.
 In combination with an emptyDir volume that's shared with the Keycloak container, we copy the theme over to the right place where Keycloak will pick it up automatically.
@@ -40,7 +40,7 @@ parameters:
   keycloak:
     extraInitContainers:
       theme-provider:
-        image: company/keycloak-theme:v1.0.0
+        image: company/keycloak-themes:v1.0.0
         imagePullPolicy: IfNotPresent
         command:
           - sh
@@ -48,18 +48,30 @@ parameters:
           - -c
           - |
             echo "Copying theme..."
-            cp -R /theme/* /company-theme
+            cp -R /themes/* /target/
         volumeMounts:
-          - name: theme
-            mountPath: /company-theme
+          - name: themes
+            mountPath: /target
+
     extraVolumes:
-      theme:
+      themes:
         emptyDir: {}
+
     extraVolumeMounts:
-      theme:
-        readOnly: true
+      theme-company:
+        name: themes
         mountPath: /opt/jboss/keycloak/themes/company
+        subPath: company
+        readOnly: true
+      theme-other:
+        name: themes
+        readOnly: true
+        mountPath: /opt/jboss/keycloak/themes/other-theme
+        subPath: other-theme
+        readOnly: true
 ----
+
+Note that simply mounting the "themes" volume to `+/opt/jboss/keycloak/themes+` will overwrite the default Keycloak themes.
 
 [TIP]
 ====

--- a/docs/modules/ROOT/pages/how-tos/db-tls.adoc
+++ b/docs/modules/ROOT/pages/how-tos/db-tls.adoc
@@ -121,3 +121,5 @@ parameters:
       extraVolumes: ""
       extraVolumeMounts: ""
 ----
+
+Note that this will also remove the default volumeMounts added by the Chart, like "startup" and "keycloak-tls."

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -404,6 +404,8 @@ Extra volume mounts added to the Keycloak container.
 Keys in the dict are used as value for field `name` in the resulting volume mount configuration.
 Values must be valid Kubernetes volume mount configurations.
 
+Prefer this over using `helm_values.extraVolumeMounts` since with the later you'll have to make sure you don't accidentially break stuff (for example DB TLS and internal TLS are configured via extra volumes).
+
 Example:
 [source,yaml]
 ----
@@ -678,3 +680,5 @@ default:: see `defaults.yml`
 
 All helm_values are passed to the helm chart.
 This allows to configure all https://github.com/codecentric/helm-charts/tree/keycloak-10.3.1/charts/keycloak#configuration[keycloak helm chart values].
+
+Note that it's your own liability to make sure you don't break stuff by overwriting values here!

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -410,7 +410,8 @@ Example:
 parameters:
   keycloak:
     extraVolumeMounts:
-      theme:
+      theme-vshn:
+        name: theme
         readOnly: true
         mountPath: /opt/jboss/keycloak/themes/vshn
 ----

--- a/tests/builtin.yml
+++ b/tests/builtin.yml
@@ -21,9 +21,10 @@ parameters:
           - name: theme
             mountPath: /company-theme
     extraVolumes:
-      test:
+      theme:
         emptyDir: {}
     extraVolumeMounts:
       test:
+        name: theme
         readOnly: true
         mountPath: /opt/test

--- a/tests/builtin/statefulset_keycloak_test.go
+++ b/tests/builtin/statefulset_keycloak_test.go
@@ -30,6 +30,10 @@ func Test_Keycloak_StatefulSet_Secrets(t *testing.T) {
 
 	envFrom := subject.Spec.Template.Spec.Containers[0].EnvFrom
 	assert.Equal(t, expectedDbSecretName, envFrom[1].SecretRef.Name)
+}
+
+func Test_Keycloak_StatefulSet_InitContainers(t *testing.T) {
+	subject := common.DecodeStatefulsetV1(t, testPath+"/01_keycloak_helmchart/keycloak/templates/statefulset.yaml")
 
 	assert.Len(t, subject.Spec.Template.Spec.InitContainers, 2)
 	for _, c := range subject.Spec.Template.Spec.InitContainers {
@@ -37,24 +41,50 @@ func Test_Keycloak_StatefulSet_Secrets(t *testing.T) {
 			assert.Equal(t, "company/keycloak-theme:v1.0.0", c.Image)
 		}
 	}
+}
 
-	assert.Len(t, subject.Spec.Template.Spec.Volumes, 4)
-	containsTest := false
+func Test_Keycloak_StatefulSet_Volumes(t *testing.T) {
+	subject := common.DecodeStatefulsetV1(t, testPath+"/01_keycloak_helmchart/keycloak/templates/statefulset.yaml")
+
+	volumes := make(map[string]int)
 	for _, v := range subject.Spec.Template.Spec.Volumes {
-		if v.Name == "test" {
-			containsTest = true
-		}
+		volumes[v.Name]++
 	}
-	assert.True(t, containsTest)
 
-	assert.Len(t, subject.Spec.Template.Spec.Containers[0].VolumeMounts, 4)
-	containsTest = false
-	for _, v := range subject.Spec.Template.Spec.Containers[0].VolumeMounts {
-		if v.Name == "test" {
-			containsTest = true
+	// from chart
+	assert.Equal(t, 1, volumes["startup"])
+
+	// from defaults.yml
+	assert.Equal(t, 1, volumes["db-certs"])
+	assert.Equal(t, 1, volumes["keycloak-tls"])
+
+	// from test inventory
+	assert.Equal(t, 1, volumes["theme"])
+}
+func Test_Keycloak_StatefulSet_VolumeMounts(t *testing.T) {
+	subject := common.DecodeStatefulsetV1(t, testPath+"/01_keycloak_helmchart/keycloak/templates/statefulset.yaml")
+	container := subject.Spec.Template.Spec.Containers[0]
+
+	// ensure we have the correct container
+	assert.Equal(t, "keycloak", container.Name)
+
+	assert.Len(t, container.VolumeMounts, 4)
+	volumeMounts := make(map[string]int)
+	for _, v := range container.VolumeMounts {
+		volumeMounts[v.Name]++
+
+		if v.Name == "theme" {
 			assert.Equal(t, "/opt/test", v.MountPath)
 		}
 	}
-	assert.True(t, containsTest)
 
+	// from chart
+	assert.Equal(t, 1, volumeMounts["startup"])
+
+	// from defaults.yml
+	assert.Equal(t, 1, volumeMounts["db-certs"])
+	assert.Equal(t, 1, volumeMounts["keycloak-tls"])
+
+	// from test inventory
+	assert.Equal(t, 1, volumeMounts["theme"])
 }

--- a/tests/external.yml
+++ b/tests/external.yml
@@ -8,3 +8,22 @@ parameters:
     tls:
       provider: vault
       termination: passthrough
+    extraVolumes:
+      themes:
+        emptyDir: {}
+    extraVolumeMounts:
+      themes-test:
+        name: themes
+        readOnly: true
+        mountPath: /themes/test
+        subDir: test
+      themes-foo:
+        name: themes
+        readOnly: true
+        mountPath: /themes/foo
+        subDir: foo
+      themes-bar:
+        name: themes
+        readOnly: true
+        mountPath: /themes/bar
+        subDir: bar

--- a/tests/external/statefulset_keycloak_test.go
+++ b/tests/external/statefulset_keycloak_test.go
@@ -24,8 +24,47 @@ func Test_Keycloak_StatefulSet_Secrets(t *testing.T) {
 
 	envFrom := subject.Spec.Template.Spec.Containers[0].EnvFrom
 	assert.Equal(t, expectedDbSecretName, envFrom[1].SecretRef.Name)
-
 	assert.Len(t, subject.Spec.Template.Spec.InitContainers, 0)
-	assert.Len(t, subject.Spec.Template.Spec.Volumes, 3)
-	assert.Len(t, subject.Spec.Template.Spec.Containers[0].VolumeMounts, 3)
+}
+
+func Test_Keycloak_StatefulSet_Volumes(t *testing.T) {
+	subject := common.DecodeStatefulsetV1(t, testPath+"/01_keycloak_helmchart/keycloak/templates/statefulset.yaml")
+
+	volumes := make(map[string]int)
+	for _, v := range subject.Spec.Template.Spec.Volumes {
+		volumes[v.Name]++
+	}
+
+	// from chart
+	assert.Equal(t, 1, volumes["startup"])
+
+	// from defaults.yml
+	assert.Equal(t, 1, volumes["db-certs"])
+	assert.Equal(t, 1, volumes["keycloak-tls"])
+
+	// from test inventory
+	assert.Equal(t, 1, volumes["themes"])
+}
+func Test_Keycloak_StatefulSet_VolumeMounts(t *testing.T) {
+	subject := common.DecodeStatefulsetV1(t, testPath+"/01_keycloak_helmchart/keycloak/templates/statefulset.yaml")
+	container := subject.Spec.Template.Spec.Containers[0]
+
+	// ensure we have the correct container
+	assert.Equal(t, "keycloak", container.Name)
+
+	assert.Len(t, container.VolumeMounts, 6)
+	volumeMounts := make(map[string]int)
+	for _, v := range container.VolumeMounts {
+		volumeMounts[v.Name]++
+	}
+
+	// from chart
+	assert.Equal(t, 1, volumeMounts["startup"])
+
+	// from defaults.yml
+	assert.Equal(t, 1, volumeMounts["db-certs"])
+	assert.Equal(t, 1, volumeMounts["keycloak-tls"])
+
+	// from test inventory
+	assert.Equal(t, 3, volumeMounts["themes"])
 }


### PR DESCRIPTION
Follow-up to #79

This commit adds support for mounting the same volume multiple times, required for the "multiple themes" use case.

Since simply mounting the themes volume to `/opt/jboss/keycloak/themes` would overwrite the default/builtin themes, multiple mounts are required.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.