### PR TITLE
Ensure OpenShift Routes use correct TLS termination

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -13,15 +13,19 @@ parameters:
         passthrough:
           certmanager:
             nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+            route.openshift.io/termination: "passthrough"
           vault:
             nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+            route.openshift.io/termination: "passthrough"
         reencrypt:
           certmanager:
             kubernetes.io/tls-acme: "true"
             cert-manager.io/cluster-issuer: ${keycloak:tls:certmanager:issuer:name}
             nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+            route.openshift.io/termination: "reencrypt"
           vault:
             nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+            route.openshift.io/termination: "reencrypt"
 
     namespace: syn-${_instance}
     release_name: keycloak


### PR DESCRIPTION
This change will ensure that OpenShift routes always use the correct TLS
termination type.

Relates: #80

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] ~~Update the documentation.~~
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
