### PR TITLE
Add support for OpenShift service serving certs

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -8,7 +8,7 @@ parameters:
       external: false
     =_ingress_annotations:
       # This lookup table controls whether to set specific annotations depending on the value of `keycloak.ingress.controller`,
-      # `keycloak.tls.termination` and `keycloak.ingress.tls.provider`
+      # `keycloak.ingress.tls.termination` and `keycloak.ingress.tls.provider`
       nginx:
         passthrough:
           _passthrough: &passthrough
@@ -24,6 +24,13 @@ parameters:
             <<: *reencrypt
             cert-manager.io/cluster-issuer: ${keycloak:ingress:tls:certmanager:issuer}
           vault: *reencrypt
+
+    =_service_annotations:
+      # lookup table for service annotations based on `keycloak.tls.provider`:
+      certmanager: {}
+      openshift:
+        service.beta.openshift.io/serving-cert-secret-name: ${keycloak:tls:secretName}
+      vault: {}
 
     namespace: syn-${_instance}
     release_name: keycloak
@@ -227,6 +234,7 @@ parameters:
               matchLabels:
                 name: ${keycloak:ingress:controllerNamespace}
       service:
+        annotations: ${keycloak:_service_annotations:${keycloak:tls:provider}}
         # Workaround until https://github.com/codecentric/helm-charts/pull/432 is solved
         httpPort: 8080
         labels: ${keycloak:labels}

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -123,7 +123,7 @@ local ingress_tls_secret = kube.Secret(params.ingress.tls.secretName) {
 };
 
 local create_keycloak_cert_secret =
-  params.ingress.enabled && !(params.ingress.tls.termination == 'passthrough' && params.tls.provider == 'certmanager');
+  params.tls.provider != 'openshift' && params.ingress.enabled && !(params.ingress.tls.termination == 'passthrough' && params.tls.provider == 'certmanager');
 local create_ingress_cert_secret =
   params.ingress.enabled && params.ingress.tls.termination == 'reencrypt' && params.tls.provider == 'vault';
 local create_ingress_cert =

--- a/docs/modules/ROOT/pages/how-tos/keycloak-tls.adoc
+++ b/docs/modules/ROOT/pages/how-tos/keycloak-tls.adoc
@@ -1,5 +1,19 @@
 = Setup a TLS certificate for Keycloak
 
+[NOTE]
+.Use service serving certificates on OCP4
+====
+On OpenShift 4, use the "openshift" TLS provider instead, to get a certificate that works with the OpenShift router, is valid for 2 years and will be autorenewed:
+
+[source,yaml]
+----
+parameters:
+  keycloak:
+    tls:
+      provider: openshift
+----
+====
+
 This guide provides an example how to setup a TLS certificate for Keycloak.
 
 ====

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -112,6 +112,7 @@ Defines how TLS certificates are provisioned:
 
 * `certmanager` for certificates issued via cert-manager.
 * `vault` for certificates stored in Vault.
+* `openshift` for https://docs.openshift.com/container-platform/4.9/security/certificates/service-serving-certificate.html[service serving certificates]
 
 
 === `tls.provider`

--- a/tests/golden/openshift/openshift/apps/openshift.yaml
+++ b/tests/golden/openshift/openshift/apps/openshift.yaml
@@ -1,0 +1,6 @@
+spec:
+  ignoreDifferences:
+    - group: ''
+      jsonPointers:
+        - /imagePullSecrets
+      kind: ServiceAccount

--- a/tests/golden/openshift/openshift/openshift/00_namespace.yaml
+++ b/tests/golden/openshift/openshift/openshift/00_namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations: {}
+  labels:
+    SYNMonitoring: main
+    name: keycloak-dev
+  name: keycloak-dev

--- a/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloak/templates/configmap-startup.yaml
+++ b/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloak/templates/configmap-startup.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+data:
+  keycloak.cli: 'embed-server --server-config=standalone-ha.xml --std-out=echo
+
+    batch
+
+
+    echo Configuring node identifier
+
+
+    ## Sets the node identifier to the node name (= pod name). Node identifiers have
+    to be unique. They can have a
+
+    ## maximum length of 23 characters. Thus, the chart''s fullname template truncates
+    its length accordingly.
+
+    /subsystem=transactions:write-attribute(name=node-identifier, value=${jboss.node.name})
+
+
+    echo Finished configuring node identifier
+
+
+    run-batch
+
+    stop-embedded-server
+
+    '
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: keycloak
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/version: 14.0.0
+    helm.sh/chart: keycloak-10.3.1
+  name: keycloak-startup

--- a/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloak/templates/ingress.yaml
+++ b/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloak/templates/ingress.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+    route.openshift.io/termination: reencrypt
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: openshift
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/version: v11.0.0
+    helm.sh/chart: keycloak-10.3.1
+  name: keycloak
+spec:
+  rules:
+    - host: keycloak.example.com
+      http:
+        paths:
+          - backend:
+              service:
+                name: keycloak-http
+                port:
+                  name: https
+            path: /
+            pathType: Prefix
+  tls:
+    - hosts:
+        - keycloak.example.com
+      secretName: ingress-tls

--- a/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloak/templates/prometheusrule.yaml
+++ b/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloak/templates/prometheusrule.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: openshift
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/version: v11.0.0
+    helm.sh/chart: keycloak-10.3.1
+  name: keycloak
+spec:
+  groups:
+    - name: keycloak
+      rules: []

--- a/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloak/templates/service-headless.yaml
+++ b/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloak/templates/service-headless.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: headless
+    app.kubernetes.io/instance: keycloak
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/version: 14.0.0
+    helm.sh/chart: keycloak-10.3.1
+  name: keycloak-headless
+spec:
+  clusterIP: None
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: http
+  selector:
+    app.kubernetes.io/instance: keycloak
+    app.kubernetes.io/name: keycloak
+  type: ClusterIP

--- a/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloak/templates/service-http.yaml
+++ b/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloak/templates/service-http.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: keycloak-tls
+  labels:
+    app.kubernetes.io/component: http
+    app.kubernetes.io/instance: openshift
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/version: v11.0.0
+    helm.sh/chart: keycloak-10.3.1
+  name: keycloak-http
+spec:
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: http
+    - name: https
+      port: 8443
+      protocol: TCP
+      targetPort: https
+    - name: http-management
+      port: 9990
+      protocol: TCP
+      targetPort: http-management
+  selector:
+    app.kubernetes.io/instance: keycloak
+    app.kubernetes.io/name: keycloak
+  type: ClusterIP

--- a/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloak/templates/serviceaccount.yaml
+++ b/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloak/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+imagePullSecrets: []
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: openshift
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/version: v11.0.0
+    helm.sh/chart: keycloak-10.3.1
+  name: keycloak

--- a/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloak/templates/servicemonitor.yaml
+++ b/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloak/templates/servicemonitor.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: openshift
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/version: v11.0.0
+    helm.sh/chart: keycloak-10.3.1
+  name: keycloak-wildfly
+spec:
+  endpoints:
+    - interval: 10s
+      path: /metrics
+      port: http-management
+      scrapeTimeout: 10s
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: http
+      app.kubernetes.io/instance: keycloak
+      app.kubernetes.io/name: keycloak

--- a/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloak/templates/statefulset.yaml
+++ b/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloak/templates/statefulset.yaml
@@ -1,0 +1,188 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: openshift
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/version: v11.0.0
+    helm.sh/chart: keycloak-10.3.1
+  name: keycloak
+spec:
+  podManagementPolicy: Parallel
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: keycloak
+      app.kubernetes.io/name: keycloak
+  serviceName: keycloak-headless
+  template:
+    metadata:
+      annotations:
+        checksum/config-startup: 364a72f43635e8b1de86a1292b18f3710e733bd6aebf6d9751fbbe9390312aac
+        checksum/secrets: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+      labels:
+        app.kubernetes.io/instance: keycloak
+        app.kubernetes.io/name: keycloak
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/component
+                  operator: NotIn
+                  values:
+                  - test
+                matchLabels:
+                  app.kubernetes.io/instance: keycloak
+                  app.kubernetes.io/name: keycloak
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+            weight: 100
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: NotIn
+                values:
+                - test
+              matchLabels:
+                app.kubernetes.io/instance: keycloak
+                app.kubernetes.io/name: keycloak
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args: []
+        command: []
+        env:
+        - name: CACHE_OWNERS_AUTH_SESSIONS_COUNT
+          value: '2'
+        - name: CACHE_OWNERS_COUNT
+          value: '2'
+        - name: JAVA_OPTS
+          value: -XX:+UseContainerSupport -XX:MaxRAMPercentage=50.0 -Djava.net.preferIPv4Stack=true
+            -Djboss.modules.system.pkgs=$JBOSS_MODULES_SYSTEM_PKGS -Djava.awt.headless=true
+        - name: JGROUPS_DISCOVERY_PROPERTIES
+          value: dns_query=keycloak-headless.keycloak-dev.svc.cluster.local
+        - name: JGROUPS_DISCOVERY_PROTOCOL
+          value: dns.DNS_PING
+        - name: KEYCLOAK_STATISTICS
+          value: all
+        - name: PROXY_ADDRESS_FORWARDING
+          value: 'true'
+        envFrom:
+        - secretRef:
+            name: keycloak-admin-user
+        - secretRef:
+            name: keycloak-postgresql
+        image: quay.io/keycloak/keycloak:14.0.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /auth/
+            port: http
+          initialDelaySeconds: 0
+          timeoutSeconds: 5
+        name: keycloak
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        - containerPort: 9990
+          name: http-management
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /auth/realms/master
+            port: http
+          initialDelaySeconds: 30
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: '1'
+            memory: 1Gi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        securityContext: null
+        startupProbe:
+          failureThreshold: 60
+          httpGet:
+            path: /auth/
+            port: http
+          initialDelaySeconds: 30
+          periodSeconds: 5
+          timeoutSeconds: 1
+        volumeMounts:
+        - mountPath: /opt/jboss/certs
+          name: db-certs
+          readOnly: true
+        - mountPath: /etc/x509/https
+          name: keycloak-tls
+          readOnly: true
+        - mountPath: /opt/jboss/startup-scripts/keycloak.cli
+          name: startup
+          readOnly: true
+          subPath: keycloak.cli
+        - mountPath: /opt/jboss/keycloak/themes/app1
+          name: themes
+          subPath: app1
+        - mountPath: /opt/jboss/keycloak/themes/app2
+          name: themes
+          subPath: app2
+        - mountPath: /opt/jboss/keycloak/themes/customer
+          name: themes
+          subPath: customer
+        - mountPath: /opt/jboss/keycloak/themes/dev-app1
+          name: themes
+          subPath: dev-app1
+        - mountPath: /opt/jboss/keycloak/themes/dev-app2
+          name: themes
+          subPath: dev-app2
+        - mountPath: /opt/jboss/keycloak/themes/int-app1
+          name: themes
+          subPath: int-app1
+        - mountPath: /opt/jboss/keycloak/themes/int-app2
+          name: themes
+          subPath: int-app2
+      enableServiceLinks: true
+      initContainers:
+      - args:
+        - -c
+        - |
+          echo "Copying theme..."
+          cp -Rv /themes/* /target/
+        command:
+        - sh
+        image: image-registry.openshift-image-registry.svc:5000/builds/customer-keycloak-theme:dev
+        imagePullPolicy: Always
+        name: theme-provider
+        volumeMounts:
+        - mountPath: /target
+          name: themes
+      restartPolicy: Always
+      securityContext: null
+      serviceAccountName: keycloak
+      terminationGracePeriodSeconds: 60
+      volumes:
+      - emptyDir: {}
+        name: db-certs
+      - name: keycloak-tls
+        secret:
+          defaultMode: 420
+          secretName: keycloak-tls
+      - configMap:
+          defaultMode: 365
+          items:
+          - key: keycloak.cli
+            path: keycloak.cli
+          name: keycloak-startup
+        name: startup
+      - emptyDir: {}
+        name: themes
+  updateStrategy:
+    type: RollingUpdate

--- a/tests/golden/openshift/openshift/openshift/10_admin_secret.yaml
+++ b/tests/golden/openshift/openshift/openshift/10_admin_secret.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: openshift
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/version: v11.0.0
+    name: keycloak-admin-user
+  name: keycloak-admin-user
+stringData:
+  KEYCLOAK_PASSWORD: t-silent-test-1234/c-green-test-1234/openshift/admin-password
+  KEYCLOAK_USER: t-silent-test-1234/c-green-test-1234/openshift/admin-username
+type: Opaque

--- a/tests/golden/openshift/openshift/openshift/11_db_secret.yaml
+++ b/tests/golden/openshift/openshift/openshift/11_db_secret.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: openshift
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/version: v11.0.0
+    name: keycloak-postgresql
+  name: keycloak-postgresql
+stringData:
+  DB_ADDR: maxscale-masteronly
+  DB_DATABASE: keycloak_dev
+  DB_PASSWORD: t-silent-test-1234/c-green-test-1234/openshift/db-password
+  DB_PORT: '3306'
+  DB_USER: keycloak_dev
+  DB_VENDOR: mariadb
+  JDBC_PARAMS: sslmode=verify-ca&sslrootcert=/opt/jboss/certs/tls.crt
+type: Opaque

--- a/tests/openshift.yml
+++ b/tests/openshift.yml
@@ -1,0 +1,80 @@
+---
+parameters:
+  keycloak:
+    namespace: keycloak-dev
+    tls:
+      provider: openshift
+    admin:
+      username: "?{vaultkv:${cluster:tenant}/${cluster:name}/${_instance}/admin-username}"
+      password: "?{vaultkv:${cluster:tenant}/${cluster:name}/${_instance}/admin-password}"
+
+    helm_values:
+      podSecurityContext: null
+      securityContext: null
+      pgchecker:
+        securityContext: null
+      image:
+        tag: "14.0.0"
+
+    database:
+      database: keycloak_dev
+      username: keycloak_dev
+      provider: external
+      tls:
+        enabled: false
+      external:
+        host: maxscale-masteronly
+        vendor: mariadb
+        port: 3306
+
+    extraVolumes:
+      themes:
+        emptyDir: {}
+      # overwrite the default that mounts a secret
+      db-certs:
+        emptyDir: {}
+
+    extraInitContainers:
+      theme-provider:
+        image: image-registry.openshift-image-registry.svc:5000/builds/customer-keycloak-theme:dev
+        imagePullPolicy: Always
+        command:
+          - sh
+        args:
+          - -c
+          - |
+            echo "Copying theme..."
+            cp -Rv /themes/* /target/
+        volumeMounts:
+          - name: themes
+            mountPath: /target
+
+    extraVolumeMounts:
+      theme-customer:
+        name: themes
+        mountPath: /opt/jboss/keycloak/themes/customer
+        subPath: customer
+      theme-app1:
+        name: themes
+        mountPath: /opt/jboss/keycloak/themes/app1
+        subPath: app1
+      theme-app2:
+        name: themes
+        mountPath: /opt/jboss/keycloak/themes/app2
+        subPath: app2
+      theme-int-app1:
+        name: themes
+        mountPath: /opt/jboss/keycloak/themes/int-app1
+        subPath: int-app1
+      theme-int-app2:
+        name: themes
+        mountPath: /opt/jboss/keycloak/themes/int-app2
+        subPath: int-app2
+      theme-dev-app1:
+        name: themes
+        mountPath: /opt/jboss/keycloak/themes/dev-app1
+        subPath: dev-app1
+      theme-dev-app2:
+        name: themes
+        mountPath: /opt/jboss/keycloak/themes/dev-app2
+        subPath: dev-app2


### PR DESCRIPTION
In addition to certmanager- or vault-provided certificates, this commit
adds support to use openshift-provided "service serving certificates".

Based off #89

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.
