### PR TITLE
Remove unused ACME annotation

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -22,7 +22,6 @@ parameters:
             route.openshift.io/termination: "reencrypt"
           certmanager:
             <<: *reencrypt
-            kubernetes.io/tls-acme: "true"
             cert-manager.io/cluster-issuer: ${keycloak:tls:certmanager:issuer:name}
           vault: *reencrypt
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -213,7 +213,6 @@ parameters:
   keycloak:
     ingress:
       annotations:
-        kubernetes.io/tls-acme: 'true'
         cert-manager.io/cluster-issuer: letsencrypt-production
 ----
 


### PR DESCRIPTION
The "kubernetes.io/tls-acme" annotation does not do anything anymore and should be removed since it seems to confuse users.

Based off #91 

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] ~~Link this PR to related issues.~~
