### PR TITLE
Update to Helm v3 parameters

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -26,7 +26,7 @@ parameters:
           vault: *reencrypt
 
     namespace: syn-${_instance}
-    release_name: keycloak
+    name: keycloak
     charts:
       keycloak: "10.3.1"
     # FQDN should be overwritten on the cluster level

--- a/class/keycloak.yml
+++ b/class/keycloak.yml
@@ -25,7 +25,7 @@ parameters:
         input_paths:
           - keycloak/helmcharts/keycloak/${keycloak:charts:keycloak}/
         helm_params:
-          release_name: ${keycloak:release_name}
+          name: ${keycloak:name}
           namespace: "${keycloak:namespace}"
           # Tell Helm to generate networking.k8s.io/v1 Ingress objects
           # This specifies argument `-a networking.k8s.io/v1/Ingress` for

--- a/component/prometheus-netpol.jsonnet
+++ b/component/prometheus-netpol.jsonnet
@@ -11,7 +11,7 @@ local prometheus_namespace =
 local prometheus_name = 'prometheus';
 
 local keycloak_namespace = params.namespace;
-local keycloak_name = params.release_name;
+local keycloak_name = params.name;
 
 local name = prometheus_name + '-' + prometheus_namespace + '-to-' + keycloak_name;
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -16,7 +16,7 @@ When using multiple instances for this component, each instance needs its own na
 You can't deploy multiple instances into the same namespace.
 ====
 
-== `release_name`
+== `name`
 
 [horizontal]
 type:: string
@@ -48,7 +48,7 @@ FQDN should be overwritten on the cluster level.
 
 [horizontal]
 type:: string
-default:: `${keycloak:release_name}-admin-user`
+default:: `${keycloak:name}-admin-user`
 
 
 == `admin.username`
@@ -574,7 +574,7 @@ See xref:how-tos/change-passwords.adoc[Change passwords] to change the password 
 
 [horizontal]
 type:: string
-default:: `${keycloak:release_name}-postgresql`
+default:: `${keycloak:name}-postgresql`
 
 
 == `database.external.vendor`


### PR DESCRIPTION
When compiling the component, a warning would be emmitted:

> using 'release_name' to specify the output name is deprecated. Use
> 'name' instead

This commit addresses this.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.
