### PR TITLE
Fix backup command for builtin PostgreSQL DB

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -253,6 +253,7 @@ parameters:
         # TODO: Rename master to primary when upgrading to Postgres 11 https://github.com/bitnami/charts/commit/7eabc85fd4fae43127228a22829c7ce3fe85c389
         master:
           podAnnotations:
+            # Annotations to support both K8up v1 and v2
             k8up.syn.tools/backupcommand: sh -c 'PGDATABASE="$POSTGRES_DB" PGUSER="$POSTGRES_USER" PGPASSWORD="$POSTGRES_PASSWORD" pg_dump --clean'
             k8up.syn.tools/file-extension: .sql
             k8up.io/backupcommand: sh -c 'PGDATABASE="$POSTGRES_DB" PGUSER="$POSTGRES_USER" PGPASSWORD="$POSTGRES_PASSWORD" pg_dump --clean'

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -252,8 +252,11 @@ parameters:
           registry: quay.io
         # TODO: Rename master to primary when upgrading to Postgres 11 https://github.com/bitnami/charts/commit/7eabc85fd4fae43127228a22829c7ce3fe85c389
         master:
-          annotations:
-            k8up.syn.tools/backupcommand: sh -c 'PGDATABASE="$POSTGRES_DB" PGUSER="$POSTGRES_USER" PGPASSWORD="$POSTGRES_PASSWORD" pg_dump'
+          podAnnotations:
+            k8up.syn.tools/backupcommand: sh -c 'PGDATABASE="$POSTGRES_DB" PGUSER="$POSTGRES_USER" PGPASSWORD="$POSTGRES_PASSWORD" pg_dump --clean'
+            k8up.syn.tools/file-extension: .sql
+            k8up.io/backupcommand: sh -c 'PGDATABASE="$POSTGRES_DB" PGUSER="$POSTGRES_USER" PGPASSWORD="$POSTGRES_PASSWORD" pg_dump --clean'
+            k8up.io/file-extension: .sql
           labels: ${keycloak:labels}
         volumePermissions:
           enabled: ${keycloak:database:tls:enabled}

--- a/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloak/charts/postgresql/templates/statefulset.yaml
+++ b/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloak/charts/postgresql/templates/statefulset.yaml
@@ -1,9 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  annotations:
-    k8up.syn.tools/backupcommand: sh -c 'PGDATABASE="$POSTGRES_DB" PGUSER="$POSTGRES_USER"
-      PGPASSWORD="$POSTGRES_PASSWORD" pg_dump'
+  annotations: null
   labels:
     app.kubernetes.io/component: keycloak
     app.kubernetes.io/instance: builtin
@@ -21,6 +19,13 @@ spec:
   serviceName: keycloak-postgresql-headless
   template:
     metadata:
+      annotations:
+        k8up.io/backupcommand: sh -c 'PGDATABASE="$POSTGRES_DB" PGUSER="$POSTGRES_USER"
+          PGPASSWORD="$POSTGRES_PASSWORD" pg_dump --clean'
+        k8up.io/file-extension: .sql
+        k8up.syn.tools/backupcommand: sh -c 'PGDATABASE="$POSTGRES_DB" PGUSER="$POSTGRES_USER"
+          PGPASSWORD="$POSTGRES_PASSWORD" pg_dump --clean'
+        k8up.syn.tools/file-extension: .sql
       labels:
         app.kubernetes.io/instance: keycloak
         app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
* Switch to annotation on pod instead of on StS
* Add both `k8up.io` and `k8up.syn.tools` annotation to support k8up 2.0
* Add file-extention annotation
* Add `--clean` flag for a conistent restore




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
