### PR TITLE
Allow users to add custom labels to the Keycloak namespace

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -38,6 +38,8 @@ parameters:
       keycloak: "10.3.1"
     # FQDN should be overwritten on the cluster level
     fqdn: keycloak.example.com
+    # Namespace labels
+    namespaceLabels: {}
     # Keycloak Admin
     admin:
       secretname: keycloak-admin-user

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -1,5 +1,6 @@
 // main template for keycloak
 local k8up = import 'lib/backup-k8up.libjsonnet';
+local com = import 'lib/commodore.libjsonnet';
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
 local rl = import 'lib/resource-locker.libjsonnet';
@@ -11,7 +12,7 @@ local namespace = kube.Namespace(params.namespace) {
   metadata+: {
     labels+: {
       SYNMonitoring: 'main',
-    },
+    } + com.makeMergeable(params.namespaceLabels),
   },
 };
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -16,6 +16,21 @@ When using multiple instances for this component, each instance needs its own na
 You can't deploy multiple instances into the same namespace.
 ====
 
+== `namespaceLabels`
+
+[horizontal]
+type:: dict
+default:: `{}`
+
+Additional labels to add to the component's namespace.
+Key value pairs in the dict are directly added to the generated namespace manifest.
+
+[IMPORTANT]
+====
+Users must ensure that the provided key value pairs are valid Kubernetes label keys and label values.
+In particular, make sure to quote boolean or string label values as otherwise the namespace may get created without any labels.
+====
+
 == `name`
 
 [horizontal]

--- a/tests/builtin.yml
+++ b/tests/builtin.yml
@@ -1,6 +1,8 @@
 ---
 parameters:
   keycloak:
+    namespaceLabels:
+      test: testing
     extraEnv:
       FOO:
         value: "bar"

--- a/tests/builtin/namespace_test.go
+++ b/tests/builtin/namespace_test.go
@@ -1,0 +1,23 @@
+package builtin
+
+import (
+	"testing"
+
+	"github.com/projectsyn/component-keycloak/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	expectedNsLabels = map[string]string{
+		"SYNMonitoring": "main",
+		"name":          "syn-builtin",
+		"test":          "testing",
+	}
+)
+
+func Test_NamespaceLabels(t *testing.T) {
+	ns := common.DecodeNamespace(t, testPath+"/00_namespace.yaml")
+	require.NotEmpty(t, ns.Labels)
+	assert.Equal(t, ns.Labels, expectedNsLabels)
+}

--- a/tests/common/boilerplate.go
+++ b/tests/common/boilerplate.go
@@ -29,6 +29,13 @@ func DecodeSecret(t *testing.T, path string) *corev1.Secret {
 	return DecodeWithSchema(t, path, subject, scheme).(*corev1.Secret)
 }
 
+func DecodeNamespace(t *testing.T, path string) *corev1.Namespace {
+	subject := &corev1.Namespace{}
+	scheme := NewSchemeWithDefault(t)
+	require.NoError(t, corev1.AddToScheme(scheme))
+	return DecodeWithSchema(t, path, subject, scheme).(*corev1.Namespace)
+}
+
 func DecodeWithSchema(t *testing.T, path string, into runtime.Object, schema *runtime.Scheme) runtime.Object {
 	data, err := ioutil.ReadFile(path)
 	require.NoError(t, err)

--- a/tests/golden/builtin/builtin/builtin/00_namespace.yaml
+++ b/tests/golden/builtin/builtin/builtin/00_namespace.yaml
@@ -5,4 +5,5 @@ metadata:
   labels:
     SYNMonitoring: main
     name: syn-builtin
+    test: testing
   name: syn-builtin


### PR DESCRIPTION


## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
