### PR TITLE
Create ingress TLS secret based on provider

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -128,7 +128,7 @@ local ingress_tls_secret = kube.Secret(params.ingress.tls.secretName) {
 local create_keycloak_cert_secret =
   params.tls.provider != 'openshift' && params.ingress.enabled && !(params.ingress.tls.termination == 'passthrough' && params.tls.provider == 'certmanager');
 local create_ingress_cert_secret =
-  params.ingress.enabled && params.ingress.tls.termination == 'reencrypt' && params.tls.provider == 'vault';
+  params.ingress.enabled && params.ingress.tls.termination == 'reencrypt' && params.ingress.tls.provider == 'vault';
 local create_ingress_cert =
   params.ingress.enabled && params.ingress.tls.termination == 'passthrough' && params.tls.provider == 'certmanager';
 


### PR DESCRIPTION
For the Ingress certificate, `ingress.tls.provider` is relevant for
determining whether or not to create the secret from Vault.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

