### PR TITLE
Remove helm chart api versions networking.k8s.io/v1/Ingress

### DIFF
--- a/class/keycloak.yml
+++ b/class/keycloak.yml
@@ -32,10 +32,6 @@ parameters:
         helm_params:
           name: keycloakx
           namespace: "${keycloak:namespace}"
-          # Tell Helm to generate networking.k8s.io/v1 Ingress objects
-          # This specifies argument `-a networking.k8s.io/v1/Ingress` for
-          # `helm template`.
-          api_versions: networking.k8s.io/v1/Ingress
         helm_values: ${keycloak:helm_values}
       - output_path: ${_instance}/01_keycloak_helmchart
         input_type: helm


### PR DESCRIPTION
The keycloakx helm chart does only support v1 Ingress

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
