### PR TITLE
Fix variable database.external.host not passed to the helm chart values

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -144,7 +144,7 @@ parameters:
       # Used when `provider=external`
       external:
         vendor: postgres
-        host: postgres.example.com
+        host: keycloak-postgresql  # Default for database provider builtin. If external use the FQDN postgres.example.com.
         port: 5432
 
     k8up:
@@ -269,7 +269,7 @@ parameters:
         enabled: ${keycloak:monitoring:enabled}
       database:
         vendor: ${keycloak:database:external:vendor}
-        hostname: keycloak-postgresql
+        hostname: ${keycloak:database:external:host}
         port: ${keycloak:database:external:port}
         database: ${keycloak:database:database}
         username: ${keycloak:database:username}

--- a/tests/external.yml
+++ b/tests/external.yml
@@ -5,6 +5,8 @@ parameters:
       jdbcParams: sslmode=verify-ca&sslrootcert=/etc/ssl/certs/ca-bundle.crt
       tls:
         verification: verify
+      external:
+        host: postgres.example.com
     tls:
       provider: vault
     ingress:

--- a/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -71,7 +71,7 @@ spec:
         - name: KC_DB_URL_DATABASE
           value: keycloak
         - name: KC_DB_URL_HOST
-          value: keycloak-postgresql
+          value: postgres.example.com
         - name: KC_DB_URL_PORT
           value: '5432'
         - name: KC_DB_USERNAME
@@ -160,8 +160,8 @@ spec:
         - sh
         - -c
         - "echo 'Waiting for Database to become ready...'\n\nuntil printf \".\" &&\
-          \ nc -z -w 2 keycloak-postgresql 5432; do\n    sleep 2;\ndone;\n\necho 'Database\
-          \ OK \u2713'\n"
+          \ nc -z -w 2 postgres.example.com 5432; do\n    sleep 2;\ndone;\n\necho\
+          \ 'Database OK \u2713'\n"
         image: docker.io/busybox:1.32
         imagePullPolicy: IfNotPresent
         name: dbchecker

--- a/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -71,7 +71,7 @@ spec:
         - name: KC_DB_URL_DATABASE
           value: keycloak_dev
         - name: KC_DB_URL_HOST
-          value: keycloak-postgresql
+          value: maxscale-masteronly
         - name: KC_DB_URL_PORT
           value: '3306'
         - name: KC_DB_USERNAME
@@ -167,7 +167,7 @@ spec:
         - sh
         - -c
         - "echo 'Waiting for Database to become ready...'\n\nuntil printf \".\" &&\
-          \ nc -z -w 2 keycloak-postgresql 3306; do\n    sleep 2;\ndone;\n\necho 'Database\
+          \ nc -z -w 2 maxscale-masteronly 3306; do\n    sleep 2;\ndone;\n\necho 'Database\
           \ OK \u2713'\n"
         image: docker.io/busybox:1.32
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
The helm chart value database hostname was hardcoded to match the
internal builtin mode. This change reenables the external database
hostname is properly passed to the keycloak statefulset.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.
