### PR TITLE
Rename database certificate directory to /opt/keycloak/db-certs

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -132,7 +132,7 @@ parameters:
       password: "?{vaultkv:${cluster:tenant}/${cluster:name}/${_instance}/db-password}"
       database: keycloak
       username: keycloak
-      jdbcParams: sslmode=verify-ca&sslrootcert=/opt/jboss/certs/tls.crt
+      jdbcParams: sslmode=verify-ca&sslrootcert=/opt/keycloak/db-certs/tls.crt
 
       tls:
         enabled: true
@@ -212,7 +212,7 @@ parameters:
       extraVolumeMounts: |
         - name: db-certs
           readOnly: true
-          mountPath: /opt/jboss/certs
+          mountPath: /opt/keycloak/db-certs
         - name: keycloak-tls
           readOnly: true
           mountPath: /etc/x509/https

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -541,10 +541,10 @@ default:: `keycloak`
 
 [horizontal]
 type:: string
-default:: `sslmode=verify-ca&sslrootcert=/opt/jboss/certs/tls.crt`
+default:: `sslmode=verify-ca&sslrootcert=/opt/keycloak/db-certs/tls.crt`
 
 Please note that if you need to customize JDBC parameters, copy and append them to the default with `&`, otherwise TLS will be disabled.
-For example: `sslmode=verify-ca&sslrootcert=/opt/jboss/certs/tls.crt&mycustomparameter=somevalue`
+For example: `sslmode=verify-ca&sslrootcert=/opt/keycloak/db-certs/tls.crt&mycustomparameter=somevalue`
 
 
 == `database.password`

--- a/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -138,7 +138,7 @@ spec:
           periodSeconds: 5
           timeoutSeconds: 1
         volumeMounts:
-        - mountPath: /opt/jboss/certs
+        - mountPath: /opt/keycloak/db-certs
           name: db-certs
           readOnly: true
         - mountPath: /etc/x509/https

--- a/tests/golden/builtin/builtin/builtin/11_db_secret.yaml
+++ b/tests/golden/builtin/builtin/builtin/11_db_secret.yaml
@@ -11,7 +11,7 @@ metadata:
     name: keycloak-postgresql
   name: keycloak-postgresql
 stringData:
-  JDBC_PARAMS: sslmode=verify-ca&sslrootcert=/opt/jboss/certs/tls.crt
+  JDBC_PARAMS: sslmode=verify-ca&sslrootcert=/opt/keycloak/db-certs/tls.crt
   KC_DB_PASSWORD: t-silent-test-1234/c-green-test-1234/builtin/db-password
   postgresql-password: t-silent-test-1234/c-green-test-1234/builtin/db-password
   postgresql-postgres-password: t-silent-test-1234/c-green-test-1234/builtin/db-password

--- a/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -136,7 +136,7 @@ spec:
           periodSeconds: 5
           timeoutSeconds: 1
         volumeMounts:
-        - mountPath: /opt/jboss/certs
+        - mountPath: /opt/keycloak/db-certs
           name: db-certs
           readOnly: true
         - mountPath: /etc/x509/https

--- a/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -134,7 +134,7 @@ spec:
           periodSeconds: 5
           timeoutSeconds: 1
         volumeMounts:
-        - mountPath: /opt/jboss/certs
+        - mountPath: /opt/keycloak/db-certs
           name: db-certs
           readOnly: true
         - mountPath: /etc/x509/https

--- a/tests/golden/openshift/openshift/openshift/11_db_secret.yaml
+++ b/tests/golden/openshift/openshift/openshift/11_db_secret.yaml
@@ -11,6 +11,6 @@ metadata:
     name: keycloak-postgresql
   name: keycloak-postgresql
 stringData:
-  JDBC_PARAMS: sslmode=verify-ca&sslrootcert=/opt/jboss/certs/tls.crt
+  JDBC_PARAMS: sslmode=verify-ca&sslrootcert=/opt/keycloak/db-certs/tls.crt
   KC_DB_PASSWORD: t-silent-test-1234/c-green-test-1234/openshift/db-password
 type: Opaque


### PR DESCRIPTION
After the migration to Quarkus, the JBoss directory should not be used
anymore. It might confuse people.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.
