### PR TITLE
Scale down keycloak and delete the ingress object ahead the upgrade

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/upgrade-8.x-to-9.x.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade-8.x-to-9.x.adoc
@@ -151,7 +151,7 @@ parameters:
 
 . Disable the automated sync policy for the keycloak instance
 
-. Scale down the existing keycloak to prevent the Wildfly based instance can write to the same database:
+. Scale down the existing keycloak to prevent the Wildfly based instance writing to the same database:
 +
 [source,bash]
 ----

--- a/docs/modules/ROOT/pages/how-tos/upgrade-8.x-to-9.x.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade-8.x-to-9.x.adoc
@@ -149,8 +149,26 @@ parameters:
 
 === Apply the deployment
 
+. Disable the automated sync policy for the keycloak instance
+
+. Scale down the existing keycloak to prevent the Wildfly based instance can write to the same database:
++
+[source,bash]
+----
+kubectl -n syn-keycloak scale statefulset keycloak --replicas=0
+----
+
+. Delete the ingress object to prevent duplicate hostname issues seen on the OpenShift router:
++
+[source,bash]
+----
+kubectl -n syn-keycloak-prod delete ingress keycloak
+----
+
 . Apply the parameter changes.
 
 . Compile and push the cluster catalog.
+
+. Enable the automated sync policy for the keycloak instance
 
 . Verify that ArgoCD can sync all resources.

--- a/docs/modules/ROOT/pages/how-tos/upgrade-8.x-to-9.x.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade-8.x-to-9.x.adoc
@@ -162,7 +162,7 @@ kubectl -n syn-keycloak scale statefulset keycloak --replicas=0
 +
 [source,bash]
 ----
-kubectl -n syn-keycloak-prod delete ingress keycloak
+kubectl -n syn-keycloak delete ingress keycloak
 ----
 
 . Apply the parameter changes.


### PR DESCRIPTION
During the real world upgrade, we have seen that ArgoCD might not prune
the objects ahead, which can cause that the Wildfily keycloak and the
Quarkus keycloak instances run in parallel. This shound't be an issue,
since we migrate to the exact same version, but to be on the safe side
we better turn off the Wilfly instance ahead.

We saw also a conflict generated by the OpenShift router, having two
different named ingress objects with the same hostname. Deleting the
ingress object ahead prevents it.

## Checklist

- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
