### PR TITLE
Fix using the built-in DB with OpenShift

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -7,7 +7,7 @@
       "name": "keycloak",
       "slug": "keycloak",
       "parameter_key": "keycloak",
-      "test_cases": "builtin external openshift",
+      "test_cases": "builtin external openshift openshift-postgres",
       "add_lib": "n",
       "add_pp": "y",
       "add_golden": "y",

--- a/docs/modules/ROOT/pages/how-tos/openshift-4.adoc
+++ b/docs/modules/ROOT/pages/how-tos/openshift-4.adoc
@@ -39,14 +39,13 @@ If you are using the built-in database provider (by default unless `keycloak.dat
 parameters:
   keycloak:
     postgresql_helm_values:
-      securityContext:
-        enabled: false
-      containerSecurityContext:
-        enabled: false
-      volumePermissions:
-        securityContext:
-          runAsUser: auto
-      shmVolume:
-        chmod:
+      primary:
+        podSecurityContext:
           enabled: false
+        containerSecurityContext:
+          enabled: false
+      volumePermissions:
+        enabled: false
+      shmVolume:
+        enabled: false
 ----

--- a/docs/modules/ROOT/pages/how-tos/openshift-4.adoc
+++ b/docs/modules/ROOT/pages/how-tos/openshift-4.adoc
@@ -30,7 +30,38 @@ parameters:
         securityContext: null
 ----
 
-== Parameters for built-in Postgresql database
+== Parameters for built-in Postgresql database on OpenShift 4.11 and higher
+
+If you are using the built-in database provider (by default unless `keycloak.database.provider` is overridden) you also need to adjust the following parameters.
+
+[source,yaml,subs="attributes+"]
+----
+parameters:
+  keycloak:
+    postgresql_helm_values:
+      primary:
+        podSecurityContext:
+          enabled: true
+          fsGroup: null
+          seccompProfile:
+            type: RuntimeDefault
+        containerSecurityContext:
+          enabled: true
+          runAsUser: null
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+          capabilities:
+            drop:
+              - ALL
+      volumePermissions:
+        enabled: false
+      shmVolume:
+        enabled: false
+----
+
+== Parameters for built-in Postgresql database up to OpenShift 4.10
 
 If you are using the built-in database provider (by default unless `keycloak.database.provider` is overridden) you also need to adjust the following parameters.
 

--- a/docs/modules/ROOT/pages/how-tos/upgrade-9.x-to-10.x.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade-9.x-to-10.x.adoc
@@ -9,8 +9,8 @@ This guide describes the steps to perform an upgrade of the component from versi
 * `postgresql_helm_values` authentication parameters have been moved to `postgresql_helm_values.auth` reflecting the https://docs.bitnami.com/kubernetes/infrastructure/postgresql/administration/upgrade/#to-1100[Helm chart upgrade] to 11.
 * `postgresql_helm_values.securityContext.enabled` changed to `postgresql_helm_values.primary.securityContext.enabled`.
 * `postgresql_helm_values.containerSecurityContext.enabled` changed to `postgresql_helm_values.primary.containerSecurityContext.enabled`.
-* `postgresql_helm_values.volumePermissions.securityContext.runAsUser` has no direct equivalent and therefore the volume permissions setup has to be disabled entirely in `postgresql_helm_values.volumePermissions.enabled`.
-* `postgresql_helm_values.shmVolume.chmod.enabled` has no direct equivalent and therefore the shared volume setup has to be disabled entirely in `postgresql_helm_values.shmVolume.enabled`.
+* `postgresql_helm_values.volumePermissions.securityContext.runAsUser` has no direct equivalent and therefore the volume permissions setup has to be disabled entirely by setting `postgresql_helm_values.volumePermissions.enabled` to `false`.
+* `postgresql_helm_values.shmVolume.chmod.enabled` has no direct equivalent and therefore the shared volume setup has to be disabled entirely by setting `postgresql_helm_values.shmVolume.enabled` to `false`.
 
 If you've configured custom values for any of those parameters, make sure to adjust your configurations when upgrading from component version v9 to v10.
 

--- a/docs/modules/ROOT/pages/how-tos/upgrade-9.x-to-10.x.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade-9.x-to-10.x.adoc
@@ -9,7 +9,7 @@ This guide describes the steps to perform an upgrade of the component from versi
 * `postgresql_helm_values` authentication parameters have been moved to `postgresql_helm_values.auth` reflecting the https://docs.bitnami.com/kubernetes/infrastructure/postgresql/administration/upgrade/#to-1100[Helm chart upgrade] to 11.
 * `postgresql_helm_values.securityContext.enabled` changed to `postgresql_helm_values.primary.securityContext.enabled`.
 * `postgresql_helm_values.containerSecurityContext.enabled` changed to `postgresql_helm_values.primary.containerSecurityContext.enabled`.
-* `postgresql_helm_values.volumePermissions.securityContext.runAsUser` has no direct equivalent and therefore the volume permissions setup has to be disabled entirly `postgresql_helm_values.volumePermissions.enabled`.
+* `postgresql_helm_values.volumePermissions.securityContext.runAsUser` has no direct equivalent and therefore the volume permissions setup has to be disabled entirely in `postgresql_helm_values.volumePermissions.enabled`.
 * `postgresql_helm_values.shmVolume.chmod.enabled` has no direct equivalent and therefore the shared volume setup has to be disabled entirly `postgresql_helm_values.shmVolume.enabled`.
 
 If you've configured custom values for any of those parameters, make sure to adjust your configurations when upgrading from component version v9 to v10.

--- a/docs/modules/ROOT/pages/how-tos/upgrade-9.x-to-10.x.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade-9.x-to-10.x.adoc
@@ -7,6 +7,10 @@ This guide describes the steps to perform an upgrade of the component from versi
 * `charts.keycloakx` changed from `1.3.2` to `1.6.0`, the Keycloak image is updated from `17.0.2` to `18.0.2`.
 * `charts.postgresql` changed from `10.16.2` to `11.6.15`, the Postgresql version remains the same version `11.14.0-debian-10-r28`.
 * `postgresql_helm_values` authentication parameters have been moved to `postgresql_helm_values.auth` reflecting the https://docs.bitnami.com/kubernetes/infrastructure/postgresql/administration/upgrade/#to-1100[Helm chart upgrade] to 11.
+* `postgresql_helm_values.securityContext.enabled` changed to `postgresql_helm_values.primary.securityContext.enabled`.
+* `postgresql_helm_values.containerSecurityContext.enabled` changed to `postgresql_helm_values.primary.containerSecurityContext.enabled`.
+* `postgresql_helm_values.volumePermissions.securityContext.runAsUser` has no direct equivalent and therefore the volume permissions setup has to be disabled entirly `postgresql_helm_values.volumePermissions.enabled`.
+* `postgresql_helm_values.shmVolume.chmod.enabled` has no direct equivalent and therefore the shared volume setup has to be disabled entirly `postgresql_helm_values.shmVolume.enabled`.
 
 If you've configured custom values for any of those parameters, make sure to adjust your configurations when upgrading from component version v9 to v10.
 

--- a/docs/modules/ROOT/pages/how-tos/upgrade-9.x-to-10.x.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade-9.x-to-10.x.adoc
@@ -10,7 +10,7 @@ This guide describes the steps to perform an upgrade of the component from versi
 * `postgresql_helm_values.securityContext.enabled` changed to `postgresql_helm_values.primary.securityContext.enabled`.
 * `postgresql_helm_values.containerSecurityContext.enabled` changed to `postgresql_helm_values.primary.containerSecurityContext.enabled`.
 * `postgresql_helm_values.volumePermissions.securityContext.runAsUser` has no direct equivalent and therefore the volume permissions setup has to be disabled entirely in `postgresql_helm_values.volumePermissions.enabled`.
-* `postgresql_helm_values.shmVolume.chmod.enabled` has no direct equivalent and therefore the shared volume setup has to be disabled entirly `postgresql_helm_values.shmVolume.enabled`.
+* `postgresql_helm_values.shmVolume.chmod.enabled` has no direct equivalent and therefore the shared volume setup has to be disabled entirely in `postgresql_helm_values.shmVolume.enabled`.
 
 If you've configured custom values for any of those parameters, make sure to adjust your configurations when upgrading from component version v9 to v10.
 

--- a/tests/golden/openshift-postgres/openshift-postgres/apps/openshift-postgres.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/apps/openshift-postgres.yaml
@@ -1,0 +1,6 @@
+spec:
+  ignoreDifferences:
+    - group: ''
+      jsonPointers:
+        - /imagePullSecrets
+      kind: ServiceAccount

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/00_namespace.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/00_namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations: {}
+  labels:
+    SYNMonitoring: main
+    name: syn-openshift-postgres
+  name: syn-openshift-postgres

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/ingress.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/ingress.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+    route.openshift.io/termination: reencrypt
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: openshift-postgres
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/version: 18.0.2
+    helm.sh/chart: keycloakx-1.6.0
+  name: keycloakx
+  namespace: syn-openshift-postgres
+spec:
+  rules:
+    - host: keycloak.example.com
+      http:
+        paths:
+          - backend:
+              service:
+                name: keycloakx-http
+                port:
+                  name: https
+            path: /
+            pathType: Prefix
+  tls:
+    - hosts:
+        - keycloak.example.com
+      secretName: ingress-tls

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/prometheusrule.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/prometheusrule.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: openshift-postgres
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/version: 18.0.2
+    helm.sh/chart: keycloakx-1.6.0
+  name: keycloakx
+  namespace: syn-openshift-postgres
+spec:
+  groups:
+    - name: keycloakx
+      rules: []

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/service-headless.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/service-headless.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: headless
+    app.kubernetes.io/instance: keycloakx
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloakx
+    app.kubernetes.io/version: 18.0.2
+    helm.sh/chart: keycloakx-1.6.0
+  name: keycloakx-headless
+  namespace: syn-openshift-postgres
+spec:
+  clusterIP: None
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: http
+  selector:
+    app.kubernetes.io/instance: keycloakx
+    app.kubernetes.io/name: keycloakx
+  type: ClusterIP

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/service-http.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/service-http.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: http
+    app.kubernetes.io/instance: openshift-postgres
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/version: 18.0.2
+    helm.sh/chart: keycloakx-1.6.0
+  name: keycloakx-http
+  namespace: syn-openshift-postgres
+spec:
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: http
+    - name: https
+      port: 8443
+      protocol: TCP
+      targetPort: https
+  selector:
+    app.kubernetes.io/instance: keycloakx
+    app.kubernetes.io/name: keycloakx
+  type: ClusterIP

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/serviceaccount.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+automountServiceAccountToken: true
+imagePullSecrets: []
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: openshift-postgres
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/version: 18.0.2
+    helm.sh/chart: keycloakx-1.6.0
+  name: keycloakx
+  namespace: syn-openshift-postgres

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/servicemonitor.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/servicemonitor.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: openshift-postgres
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/version: 18.0.2
+    helm.sh/chart: keycloakx-1.6.0
+  name: keycloakx-keycloakx
+  namespace: syn-openshift-postgres
+spec:
+  endpoints:
+    - interval: 10s
+      path: /auth/metrics
+      port: http
+      scrapeTimeout: 10s
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: http
+      app.kubernetes.io/instance: keycloakx
+      app.kubernetes.io/name: keycloakx

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -1,0 +1,188 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: openshift-postgres
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/version: 18.0.2
+    helm.sh/chart: keycloakx-1.6.0
+  name: keycloakx
+  namespace: syn-openshift-postgres
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: keycloakx
+      app.kubernetes.io/name: keycloakx
+  serviceName: keycloakx-headless
+  template:
+    metadata:
+      annotations:
+        checksum/config-startup: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        checksum/secrets: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+      labels:
+        app.kubernetes.io/instance: keycloakx
+        app.kubernetes.io/name: keycloakx
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/component
+                  operator: NotIn
+                  values:
+                  - test
+                matchLabels:
+                  app.kubernetes.io/instance: keycloakx
+                  app.kubernetes.io/name: keycloakx
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: NotIn
+                values:
+                - test
+              matchLabels:
+                app.kubernetes.io/instance: keycloakx
+                app.kubernetes.io/name: keycloakx
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - start
+        - --auto-build
+        - --http-enabled=true
+        env:
+        - name: JAVA_OPTS
+          value: -XX:+UseContainerSupport -XX:MaxRAMPercentage=50.0 -Djava.net.preferIPv4Stack=true
+            -Djava.awt.headless=true -Djgroups.dns.query=keycloakx-headless
+        - name: KC_CACHE
+          value: ispn
+        - name: KC_CACHE_STACK
+          value: kubernetes
+        - name: KC_DB
+          value: postgres
+        - name: KC_DB_URL_DATABASE
+          value: keycloak
+        - name: KC_DB_URL_HOST
+          value: keycloak-postgresql
+        - name: KC_DB_URL_PORT
+          value: '5432'
+        - name: KC_DB_USERNAME
+          value: keycloak
+        - name: KC_HEALTH_ENABLED
+          value: 'true'
+        - name: KC_HOSTNAME
+          value: keycloak.example.com
+        - name: KC_HOSTNAME_STRICT
+          value: 'false'
+        - name: KC_HTTPS_CERTIFICATE_FILE
+          value: /etc/x509/https/tls.crt
+        - name: KC_HTTPS_CERTIFICATE_KEY_FILE
+          value: /etc/x509/https/tls.key
+        - name: KC_HTTP_RELATIVE_PATH
+          value: /auth
+        - name: KC_METRICS_ENABLED
+          value: 'true'
+        - name: KC_PROXY
+          value: reencrypt
+        envFrom:
+        - secretRef:
+            name: keycloak-admin-user
+        - secretRef:
+            name: keycloak-postgresql
+        image: quay.io/keycloak/keycloak:18.0.2
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /auth/
+            port: http
+          initialDelaySeconds: 0
+          timeoutSeconds: 5
+        name: keycloak
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /auth/realms/master
+            port: http
+          initialDelaySeconds: 10
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: '1'
+            memory: 1Gi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+        startupProbe:
+          failureThreshold: 60
+          httpGet:
+            path: /auth/
+            port: http
+          initialDelaySeconds: 15
+          periodSeconds: 5
+          timeoutSeconds: 1
+        volumeMounts:
+        - mountPath: /opt/keycloak/db-certs
+          name: db-certs
+          readOnly: true
+        - mountPath: /etc/x509/https
+          name: keycloak-tls
+          readOnly: true
+      enableServiceLinks: true
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - "echo 'Waiting for Database to become ready...'\n\nuntil printf \".\" &&\
+          \ nc -z -w 2 keycloak-postgresql 5432; do\n    sleep 2;\ndone;\n\necho 'Database\
+          \ OK \u2713'\n"
+        image: docker.io/busybox:1.32
+        imagePullPolicy: IfNotPresent
+        name: dbchecker
+        resources:
+          limits:
+            cpu: 20m
+            memory: 32Mi
+          requests:
+            cpu: 20m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsGroup: 1000
+          runAsNonRoot: true
+          runAsUser: 1000
+      restartPolicy: Always
+      securityContext:
+        fsGroup: 1000
+      serviceAccountName: keycloakx
+      terminationGracePeriodSeconds: 60
+      volumes:
+      - name: db-certs
+        secret:
+          defaultMode: 256
+          items:
+          - key: tls.crt
+            path: tls.crt
+          secretName: keycloak-postgresql-tls
+      - name: keycloak-tls
+        secret:
+          defaultMode: 420
+          secretName: keycloak-tls
+  updateStrategy:
+    type: RollingUpdate

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/postgresql/templates/primary/networkpolicy.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/postgresql/templates/primary/networkpolicy.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/component: primary
+    app.kubernetes.io/instance: keycloak
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+    helm.sh/chart: postgresql-11.6.15
+  name: keycloak-postgresql-ingress
+  namespace: syn-openshift-postgres
+spec:
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/instance: keycloakx
+          app.kubernetes.io/name: keycloakx
+    ports:
+    - port: 5432
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: primary
+      app.kubernetes.io/instance: keycloak
+      app.kubernetes.io/name: postgresql

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/postgresql/templates/primary/statefulset.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/postgresql/templates/primary/statefulset.yaml
@@ -132,6 +132,14 @@ spec:
           requests:
             cpu: 250m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/bitnami/postgresql/certs
           name: postgresql-certificates
@@ -155,11 +163,22 @@ spec:
           requests:
             cpu: 250m
             memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /tmp/certs
           name: raw-certificates
         - mountPath: /opt/bitnami/postgresql/certs
           name: postgresql-certificates
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: default
       volumes:
       - name: raw-certificates

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/postgresql/templates/primary/statefulset.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/postgresql/templates/primary/statefulset.yaml
@@ -1,0 +1,181 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: openshift-postgres
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    helm.sh/chart: postgresql-11.6.15
+  name: keycloak-postgresql
+  namespace: syn-openshift-postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: primary
+      app.kubernetes.io/instance: keycloak
+      app.kubernetes.io/name: postgresql
+  serviceName: keycloak-postgresql-hl
+  template:
+    metadata:
+      annotations:
+        k8up.io/backupcommand: sh -c 'PGDATABASE="$POSTGRES_DB" PGUSER="$POSTGRES_USER"
+          PGPASSWORD="$POSTGRES_PASSWORD" pg_dump --clean'
+        k8up.io/file-extension: .sql
+        k8up.syn.tools/backupcommand: sh -c 'PGDATABASE="$POSTGRES_DB" PGUSER="$POSTGRES_USER"
+          PGPASSWORD="$POSTGRES_PASSWORD" pg_dump --clean'
+        k8up.syn.tools/file-extension: .sql
+      labels:
+        app.kubernetes.io/component: primary
+        app.kubernetes.io/instance: keycloak
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: postgresql
+        helm.sh/chart: postgresql-11.6.15
+      name: keycloak-postgresql
+    spec:
+      affinity:
+        nodeAffinity: null
+        podAffinity: null
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: primary
+                  app.kubernetes.io/instance: keycloak
+                  app.kubernetes.io/name: postgresql
+              namespaces:
+              - syn-openshift-postgres
+              topologyKey: kubernetes.io/hostname
+            weight: 1
+      containers:
+      - env:
+        - name: BITNAMI_DEBUG
+          value: 'false'
+        - name: POSTGRESQL_PORT_NUMBER
+          value: '5432'
+        - name: POSTGRESQL_VOLUME_DIR
+          value: /bitnami/postgresql
+        - name: PGDATA
+          value: /bitnami/postgresql/data
+        - name: POSTGRES_USER
+          value: keycloak
+        - name: POSTGRES_POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: postgres-password
+              name: keycloak-postgresql
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: keycloak-postgresql
+        - name: POSTGRES_DB
+          value: keycloak
+        - name: POSTGRESQL_ENABLE_LDAP
+          value: 'no'
+        - name: POSTGRESQL_ENABLE_TLS
+          value: 'yes'
+        - name: POSTGRESQL_TLS_PREFER_SERVER_CIPHERS
+          value: 'yes'
+        - name: POSTGRESQL_TLS_CERT_FILE
+          value: /opt/bitnami/postgresql/certs/tls.crt
+        - name: POSTGRESQL_TLS_KEY_FILE
+          value: /opt/bitnami/postgresql/certs/tls.key
+        - name: POSTGRESQL_LOG_HOSTNAME
+          value: 'false'
+        - name: POSTGRESQL_LOG_CONNECTIONS
+          value: 'false'
+        - name: POSTGRESQL_LOG_DISCONNECTIONS
+          value: 'false'
+        - name: POSTGRESQL_PGAUDIT_LOG_CATALOG
+          value: 'off'
+        - name: POSTGRESQL_CLIENT_MIN_MESSAGES
+          value: error
+        - name: POSTGRESQL_SHARED_PRELOAD_LIBRARIES
+          value: pgaudit
+        image: docker.io/bitnami/postgresql:11.14.0-debian-10-r28
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - exec pg_isready -U "keycloak" -d "dbname=keycloak" -h 127.0.0.1 -p 5432
+          failureThreshold: 6
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: postgresql
+        ports:
+        - containerPort: 5432
+          name: tcp-postgresql
+        readinessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - -e
+            - |
+              exec pg_isready -U "keycloak" -d "dbname=keycloak sslcert=/opt/bitnami/postgresql/certs/tls.crt sslkey=/opt/bitnami/postgresql/certs/tls.key" -h 127.0.0.1 -p 5432
+              [ -f /opt/bitnami/postgresql/tmp/.initialized ] || [ -f /bitnami/postgresql/.initialized ]
+          failureThreshold: 6
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          limits: {}
+          requests:
+            cpu: 250m
+            memory: 256Mi
+        volumeMounts:
+        - mountPath: /opt/bitnami/postgresql/certs
+          name: postgresql-certificates
+          readOnly: true
+        - mountPath: /bitnami/postgresql
+          name: data
+      hostIPC: false
+      hostNetwork: false
+      initContainers:
+      - command:
+        - /bin/sh
+        - -ec
+        - |
+          cp /tmp/certs/* /opt/bitnami/postgresql/certs/
+          chmod 600 /opt/bitnami/postgresql/certs/tls.key
+        image: docker.io/bitnami/bitnami-shell:11-debian-11-r12
+        imagePullPolicy: IfNotPresent
+        name: copy-certs
+        resources:
+          limits: {}
+          requests:
+            cpu: 250m
+            memory: 256Mi
+        volumeMounts:
+        - mountPath: /tmp/certs
+          name: raw-certificates
+        - mountPath: /opt/bitnami/postgresql/certs
+          name: postgresql-certificates
+      serviceAccountName: default
+      volumes:
+      - name: raw-certificates
+        secret:
+          secretName: keycloak-postgresql-tls
+      - emptyDir: {}
+        name: postgresql-certificates
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 8Gi

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/postgresql/templates/primary/svc-headless.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/postgresql/templates/primary/svc-headless.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: primary
+    app.kubernetes.io/instance: keycloak
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+    helm.sh/chart: postgresql-11.6.15
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: 'true'
+  name: keycloak-postgresql-hl
+  namespace: syn-openshift-postgres
+spec:
+  clusterIP: None
+  ports:
+  - name: tcp-postgresql
+    port: 5432
+    targetPort: tcp-postgresql
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/component: primary
+    app.kubernetes.io/instance: keycloak
+    app.kubernetes.io/name: postgresql
+  type: ClusterIP

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/postgresql/templates/primary/svc.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/postgresql/templates/primary/svc.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/component: primary
+    app.kubernetes.io/instance: keycloak
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+    helm.sh/chart: postgresql-11.6.15
+  name: keycloak-postgresql
+  namespace: syn-openshift-postgres
+spec:
+  ports:
+  - name: tcp-postgresql
+    nodePort: null
+    port: 5432
+    targetPort: tcp-postgresql
+  selector:
+    app.kubernetes.io/component: primary
+    app.kubernetes.io/instance: keycloak
+    app.kubernetes.io/name: postgresql
+  sessionAffinity: None
+  type: ClusterIP

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_networkpolicy_infinispan.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_networkpolicy_infinispan.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: openshift-postgres
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    name: keycloakx-infinispan
+  name: keycloakx-infinispan
+spec:
+  egress: []
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: keycloakx
+              app.kubernetes.io/name: keycloakx
+      ports:
+        - port: 7800
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: keycloakx
+      app.kubernetes.io/name: keycloakx
+  policyTypes:
+    - Ingress

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/10_admin_secret.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/10_admin_secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: openshift-postgres
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    name: keycloak-admin-user
+  name: keycloak-admin-user
+stringData:
+  KEYCLOAK_ADMIN: admin
+  KEYCLOAK_ADMIN_PASSWORD: t-silent-test-1234/c-green-test-1234/openshift-postgres/admin-password
+type: Opaque

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/11_db_secret.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/11_db_secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: openshift-postgres
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    name: keycloak-postgresql
+  name: keycloak-postgresql
+stringData:
+  JDBC_PARAMS: sslmode=verify-ca&sslrootcert=/opt/keycloak/db-certs/tls.crt
+  KC_DB_PASSWORD: t-silent-test-1234/c-green-test-1234/openshift-postgres/db-password
+  password: t-silent-test-1234/c-green-test-1234/openshift-postgres/db-password
+  postgres-password: t-silent-test-1234/c-green-test-1234/openshift-postgres/db-password
+type: Opaque

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/12_db_certs.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/12_db_certs.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: openshift-postgres
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    name: keycloak-postgresql-tls
+  name: keycloak-postgresql-tls
+stringData:
+  tls.crt: t-silent-test-1234/c-green-test-1234/openshift-postgres/server-cert
+  tls.key: t-silent-test-1234/c-green-test-1234/openshift-postgres/server-cert-key
+type: Opaque

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/13_keycloak_certs.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/13_keycloak_certs.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: openshift-postgres
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    name: keycloak-tls
+  name: keycloak-tls
+stringData:
+  ca.crt: t-silent-test-1234/c-green-test-1234/openshift-postgres/keycloak-cert
+  tls.crt: t-silent-test-1234/c-green-test-1234/openshift-postgres/keycloak-cert
+  tls.key: t-silent-test-1234/c-green-test-1234/openshift-postgres/keycloak-cert-key
+type: Opaque

--- a/tests/openshift-postgres.yml
+++ b/tests/openshift-postgres.yml
@@ -4,9 +4,20 @@ parameters:
     postgresql_helm_values:
       primary:
         podSecurityContext:
-          enabled: false
+          enabled: true
+          fsGroup: null
+          seccompProfile:
+            type: RuntimeDefault
         containerSecurityContext:
-          enabled: false
+          enabled: true
+          runAsUser: null
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+          capabilities:
+            drop:
+              - ALL
       volumePermissions:
         enabled: false
       shmVolume:

--- a/tests/openshift-postgres.yml
+++ b/tests/openshift-postgres.yml
@@ -1,0 +1,13 @@
+---
+parameters:
+  keycloak:
+    postgresql_helm_values:
+      primary:
+        podSecurityContext:
+          enabled: false
+        containerSecurityContext:
+          enabled: false
+      volumePermissions:
+        enabled: false
+      shmVolume:
+        enabled: false


### PR DESCRIPTION
Security context parameters have changed in the helm chart.

Adding an additional test, because this test case is not covered.

## Checklist

- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
