### PR TITLE
Turn off Keycloak HTTP and make the Keycloak HTTPS only

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -272,6 +272,29 @@ parameters:
         annotations: ${keycloak:_service_annotations:${keycloak:tls:provider}}
         httpPort: 8080
         labels: ${keycloak:labels}
+      livenessProbe: |
+        httpGet:
+          path: '{{ tpl .Values.http.relativePath $ | trimSuffix "/" }}/health/live'
+          port: https
+          scheme: HTTPS
+        initialDelaySeconds: 0
+        timeoutSeconds: 5
+      readinessProbe: |
+        httpGet:
+          path: '{{ tpl .Values.http.relativePath $ | trimSuffix "/" }}/health/ready'
+          port: https
+          scheme: HTTPS
+        initialDelaySeconds: 10
+        timeoutSeconds: 1
+      startupProbe: |
+        httpGet:
+          path: '{{ tpl .Values.http.relativePath $ | trimSuffix "/" }}/health'
+          port: https
+          scheme: HTTPS
+        initialDelaySeconds: 15
+        timeoutSeconds: 1
+        failureThreshold: 60
+        periodSeconds: 5
       serviceMonitor:
         enabled: ${keycloak:monitoring:enabled}
         labels: ${keycloak:labels}

--- a/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -103,7 +103,8 @@ spec:
           livenessProbe:
             httpGet:
               path: /auth/health/live
-              port: http
+              port: https
+              scheme: HTTPS
             initialDelaySeconds: 0
             timeoutSeconds: 5
           name: keycloak
@@ -117,7 +118,8 @@ spec:
           readinessProbe:
             httpGet:
               path: /auth/health/ready
-              port: http
+              port: https
+              scheme: HTTPS
             initialDelaySeconds: 10
             timeoutSeconds: 1
           resources:
@@ -134,7 +136,8 @@ spec:
             failureThreshold: 60
             httpGet:
               path: /auth/health
-              port: http
+              port: https
+              scheme: HTTPS
             initialDelaySeconds: 15
             periodSeconds: 5
             timeoutSeconds: 1

--- a/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -101,7 +101,8 @@ spec:
           livenessProbe:
             httpGet:
               path: /auth/health/live
-              port: http
+              port: https
+              scheme: HTTPS
             initialDelaySeconds: 0
             timeoutSeconds: 5
           name: keycloak
@@ -115,7 +116,8 @@ spec:
           readinessProbe:
             httpGet:
               path: /auth/health/ready
-              port: http
+              port: https
+              scheme: HTTPS
             initialDelaySeconds: 10
             timeoutSeconds: 1
           resources:
@@ -132,7 +134,8 @@ spec:
             failureThreshold: 60
             httpGet:
               path: /auth/health
-              port: http
+              port: https
+              scheme: HTTPS
             initialDelaySeconds: 15
             periodSeconds: 5
             timeoutSeconds: 1

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -101,7 +101,8 @@ spec:
           livenessProbe:
             httpGet:
               path: /auth/health/live
-              port: http
+              port: https
+              scheme: HTTPS
             initialDelaySeconds: 0
             timeoutSeconds: 5
           name: keycloak
@@ -115,7 +116,8 @@ spec:
           readinessProbe:
             httpGet:
               path: /auth/health/ready
-              port: http
+              port: https
+              scheme: HTTPS
             initialDelaySeconds: 10
             timeoutSeconds: 1
           resources:
@@ -132,7 +134,8 @@ spec:
             failureThreshold: 60
             httpGet:
               path: /auth/health
-              port: http
+              port: https
+              scheme: HTTPS
             initialDelaySeconds: 15
             periodSeconds: 5
             timeoutSeconds: 1

--- a/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -101,7 +101,8 @@ spec:
           livenessProbe:
             httpGet:
               path: /auth/health/live
-              port: http
+              port: https
+              scheme: HTTPS
             initialDelaySeconds: 0
             timeoutSeconds: 5
           name: keycloak
@@ -115,7 +116,8 @@ spec:
           readinessProbe:
             httpGet:
               path: /auth/health/ready
-              port: http
+              port: https
+              scheme: HTTPS
             initialDelaySeconds: 10
             timeoutSeconds: 1
           resources:
@@ -130,7 +132,8 @@ spec:
             failureThreshold: 60
             httpGet:
               path: /auth/health
-              port: http
+              port: https
+              scheme: HTTPS
             initialDelaySeconds: 15
             periodSeconds: 5
             timeoutSeconds: 1


### PR DESCRIPTION
This is the default for Keycloak.
HTTP is insecure.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

