### PR TITLE
Removing the network policy workaround reference

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -250,7 +250,6 @@ parameters:
                 name: ${keycloak:ingress:controllerNamespace}
       service:
         annotations: ${keycloak:_service_annotations:${keycloak:tls:provider}}
-        # Workaround until https://github.com/codecentric/helm-charts/pull/432 is solved
         httpPort: 8080
         labels: ${keycloak:labels}
       serviceMonitor:


### PR DESCRIPTION
The issue regarding network policy has been fixed in keycloak and keycloakx.

Ref: https://github.com/codecentric/helm-charts/pull/432

## Checklist

- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

