### PR TITLE
Update Ingress NGINX network policy configuration for K8s >= 1.21

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -244,10 +244,10 @@ parameters:
         extraFrom:
           - podSelector:
               matchLabels:
-                app: ingress-nginx
+                app.kubernetes.io/name: ingress-nginx
             namespaceSelector:
               matchLabels:
-                name: ${keycloak:ingress:controllerNamespace}
+                kubernetes.io/metadata.name: ${keycloak:ingress:controllerNamespace}
       service:
         annotations: ${keycloak:_service_annotations:${keycloak:tls:provider}}
         httpPort: 8080


### PR DESCRIPTION
Ingress NGINX has changed the labels from app=ingress-nginx to app.kubernetes.io/name=ingress-nginx.

Kubernetes >= 1.21 do set automatically a namespace label kubernetes.io/metadata.name: <namespace>. Therefore manually patching the namespace is no longer required.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.
