### PR TITLE
Remove SYNMonitoring and add labels for OpenShift and component-prometheus

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -3,15 +3,25 @@ local k8up = import 'lib/backup-k8up.libjsonnet';
 local com = import 'lib/commodore.libjsonnet';
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
+local prometheus = import 'lib/prometheus.libsonnet';
 local inv = kap.inventory();
 // The hiera parameters for the component
 local params = inv.parameters.keycloak;
 
-local namespace = kube.Namespace(params.namespace) {
+local namespace = (
+  if params.monitoring.enabled && std.member(inv.applications, 'prometheus') then
+    prometheus.RegisterNamespace(kube.Namespace(params.namespace))
+  else if params.monitoring.enabled && inv.parameters.facts.distribution == 'openshift4' then
+    kube.Namespace(params.namespace) {
+      metadata+: {
+        labels+: { 'openshift.io/cluster-monitoring': 'true' },
+      },
+    }
+  else
+    kube.Namespace(params.namespace)
+) + {
   metadata+: {
-    labels+: {
-      SYNMonitoring: 'main',
-    } + com.makeMergeable(params.namespaceLabels),
+    labels+: com.makeMergeable(params.namespaceLabels),
   },
 };
 

--- a/tests/builtin.yml
+++ b/tests/builtin.yml
@@ -1,5 +1,17 @@
 ---
+applications:
+  - prometheus
+
 parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-prometheus/master/lib/prometheus.libsonnet
+        output_path: vendor/lib/prometheus.libsonnet
+
+  prometheus:
+    defaultInstance: monitoring
+
   keycloak:
     namespaceLabels:
       test: testing

--- a/tests/builtin/namespace_test.go
+++ b/tests/builtin/namespace_test.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	expectedNsLabels = map[string]string{
-		"SYNMonitoring": "main",
+		"monitoring.syn.tools/monitoring": "true",
 		"name":          "syn-builtin",
 		"test":          "testing",
 	}

--- a/tests/external.yml
+++ b/tests/external.yml
@@ -1,4 +1,17 @@
+---
+applications:
+  - prometheus
+
 parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-prometheus/master/lib/prometheus.libsonnet
+        output_path: vendor/lib/prometheus.libsonnet
+
+  prometheus:
+    defaultInstance: monitoring
+
   keycloak:
     database:
       provider: external

--- a/tests/golden/builtin/builtin/builtin/00_namespace.yaml
+++ b/tests/golden/builtin/builtin/builtin/00_namespace.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   annotations: {}
   labels:
-    SYNMonitoring: main
+    monitoring.syn.tools/monitoring: 'true'
     name: syn-builtin
     test: testing
   name: syn-builtin

--- a/tests/golden/external/external/external/00_namespace.yaml
+++ b/tests/golden/external/external/external/00_namespace.yaml
@@ -3,6 +3,6 @@ kind: Namespace
 metadata:
   annotations: {}
   labels:
-    SYNMonitoring: main
+    monitoring.syn.tools/monitoring: 'true'
     name: syn-external
   name: syn-external

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/00_namespace.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/00_namespace.yaml
@@ -3,6 +3,6 @@ kind: Namespace
 metadata:
   annotations: {}
   labels:
-    SYNMonitoring: main
     name: syn-openshift-postgres
+    openshift.io/cluster-monitoring: 'true'
   name: syn-openshift-postgres

--- a/tests/golden/openshift/openshift/openshift/00_namespace.yaml
+++ b/tests/golden/openshift/openshift/openshift/00_namespace.yaml
@@ -3,6 +3,6 @@ kind: Namespace
 metadata:
   annotations: {}
   labels:
-    SYNMonitoring: main
     name: keycloak-dev
+    openshift.io/cluster-monitoring: 'true'
   name: keycloak-dev

--- a/tests/openshift-postgres.yml
+++ b/tests/openshift-postgres.yml
@@ -1,5 +1,8 @@
 ---
 parameters:
+  facts:
+    distribution: openshift4
+
   keycloak:
     namespace: syn-openshift-postgres
     postgresql_helm_values:

--- a/tests/openshift-postgres/namespace_test.go
+++ b/tests/openshift-postgres/namespace_test.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	expectedNsLabels = map[string]string{
-		"SYNMonitoring": "main",
+		"openshift.io/cluster-monitoring": "true",
 		"name":          "syn-openshift-postgres",
 	}
 	testPath = "../../compiled/openshift-postgres/openshift-postgres"

--- a/tests/openshift.yml
+++ b/tests/openshift.yml
@@ -1,5 +1,8 @@
 ---
 parameters:
+  facts:
+    distribution: openshift4
+
   keycloak:
     namespace: keycloak-dev
     tls:

--- a/tests/openshift/namespace_test.go
+++ b/tests/openshift/namespace_test.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	expectedNsLabels = map[string]string{
-		"SYNMonitoring": "main",
+		"openshift.io/cluster-monitoring": "true",
 		"name":          "keycloak-dev",
 	}
 	testPath = "../../compiled/openshift/openshift"


### PR DESCRIPTION
SYNMonitoring is no longer relevant and has been removed. Support for component-prometheus and OpenShift 4 has been added.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
