### PR TITLE
Fix monitoring network policy to use component-prometheus

### DIFF
--- a/component/prometheus-netpol.jsonnet
+++ b/component/prometheus-netpol.jsonnet
@@ -4,14 +4,11 @@ local inv = kap.inventory();
 local params = inv.parameters.keycloak;
 
 local prometheus_namespace =
-  if std.objectHas(inv.parameters, 'rancher_monitoring') then
-    inv.parameters.rancher_monitoring.namespace
-  else
-    'syn-synsights';
+  'syn-infra-monitoring';
 local prometheus_name = 'prometheus';
 
 local keycloak_namespace = params.namespace;
-local keycloak_name = params.name;
+local keycloak_name = 'keycloakx';
 
 local name = prometheus_name + '-' + prometheus_namespace + '-to-' + keycloak_name;
 
@@ -32,14 +29,14 @@ local netpol =
               },
               podSelector: {
                 matchLabels: {
-                  app: prometheus_name,
+                  'app.kubernetes.io/component': prometheus_name,
                 },
               },
             },
           ],
           ports: [
             {
-              port: 9990,
+              port: 8080,
               protocol: 'TCP',
             },
           ],

--- a/tests/golden/builtin/builtin/builtin/40_netpol.yaml
+++ b/tests/golden/builtin/builtin/builtin/40_netpol.yaml
@@ -3,8 +3,8 @@ kind: NetworkPolicy
 metadata:
   annotations: {}
   labels:
-    name: prometheus-syn-synsights-to-keycloak
-  name: prometheus-syn-synsights-to-keycloak
+    name: prometheus-syn-infra-monitoring-to-keycloakx
+  name: prometheus-syn-infra-monitoring-to-keycloakx
   namespace: syn-builtin
 spec:
   egress: []
@@ -12,16 +12,16 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
-              name: syn-synsights
+              name: syn-infra-monitoring
           podSelector:
             matchLabels:
-              app: prometheus
+              app.kubernetes.io/component: prometheus
       ports:
-        - port: 9990
+        - port: 8080
           protocol: TCP
   podSelector:
     matchLabels:
-      app.kubernetes.io/instance: keycloak
-      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/instance: keycloakx
+      app.kubernetes.io/name: keycloakx
   policyTypes:
     - Ingress


### PR DESCRIPTION
* Wildfly used the port 9990 for metrics, in Quarkus HTTP 8080 is used
* Rancher Monitoring is no longer in use and therefore being dropped
* component-prometheus is by default deployed in syn-infra-monitoring
* Label app=prometheus has been renamed to app.kubernetes.io/component=prometheus
* The keycloak label is keycloakx since the Quarkus migration

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
