### PR TITLE
Add Keycloak Pod Security Admission documentation for OpenShift 4

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/custom-theme.adoc
+++ b/docs/modules/ROOT/pages/how-tos/custom-theme.adoc
@@ -52,6 +52,13 @@ parameters:
         volumeMounts:
           - name: themes
             mountPath: /target
+        ## Hardening
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+        ## Hardening end
 
     extraVolumes:
       themes:

--- a/docs/modules/ROOT/pages/how-tos/openshift-4.adoc
+++ b/docs/modules/ROOT/pages/how-tos/openshift-4.adoc
@@ -23,6 +23,61 @@ parameters:
       # Required as the OpenShift user can not create the data directory in the keycloak directory UID 1000/GID 0
       data:
         mountPath: /opt/keycloak/data
+----
+
+== Parameters for OpenShift 4.11 and higher
+
+OpenShift 4.11 introduces https://docs.openshift.com/container-platform/4.11/release_notes/ocp-4-11-release-notes.html#ocp-4-11-auth-pod-security-admission[Pod Security Admission] globally.
+
+`runAsUser` and `runAsGroup` must be unset.
+
+The pod security context can be configured like:
+[source,yaml,subs="attributes+"]
+----
+parameters:
+  keycloak:
+    helm_values:
+      podSecurityContext:
+        fsGroup: null
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      securityContext:
+        capabilities:
+          drop:
+            - ALL
+        runAsUser: null
+      dbchecker:
+        securityContext:
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: null
+          runAsUser: null
+----
+
+You may enforce the Pod Security Admission on a namespace level:
+[source,yaml,subs="attributes+"]
+----
+parameters:
+  keycloak:
+    namespaceLabels:
+      pod-security.kubernetes.io/audit: restricted
+      pod-security.kubernetes.io/enforce: restricted
+      pod-security.kubernetes.io/warn: restricted
+      security.openshift.io/scc.podSecurityLabelSync: "false"
+----
+
+== Parameters for up to OpenShift 4.10
+
+OpenShift 4.10 and below do no support pod security admission.
+`runAsUser` and `runAsGroup` must be unset.
+
+[source,yaml,subs="attributes+"]
+----
+parameters:
+  keycloak:
     helm_values:
       podSecurityContext: null
       securityContext: null


### PR DESCRIPTION
OpenShift 4.11 introduces pod security admission globally.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
