### PR TITLE
Fix wrong provider parameter for ingress when using vault

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -150,7 +150,7 @@ local ingress_tls_secret = kube.Secret(params.ingress.tls.secretName) {
 local create_keycloak_cert_secret =
   params.tls.provider != 'openshift' && params.ingress.enabled && !(params.ingress.tls.termination == 'passthrough' && params.tls.provider == 'certmanager');
 local create_ingress_cert_secret =
-  params.ingress.enabled && params.ingress.tls.termination == 'reencrypt' && params.tls.provider == 'vault';
+  params.ingress.enabled && params.ingress.tls.termination == 'reencrypt' && params.ingress.tls.provider == 'vault';
 local create_ingress_cert =
   params.ingress.enabled && params.ingress.tls.termination == 'passthrough' && params.tls.provider == 'certmanager';
 


### PR DESCRIPTION
When using `vault` with `reencrypt` the wrong provider parameter is checked in the code. This commit fixes that




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
