### PR TITLE
Fix wrong type of tls secret for ingress object when using provider vault

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -145,6 +145,7 @@ local ingress_tls_secret = kube.Secret(params.ingress.tls.secretName) {
     'tls.key': params.ingress.tls.vault.certKey,
     'tls.crt': params.ingress.tls.vault.cert,
   },
+  type: 'kubernetes.io/tls',
 };
 
 local create_keycloak_cert_secret =


### PR DESCRIPTION
The component creates a tls secret of type `opaque` as the type is not set explicitely. This causes issues with the operator, as the operator expects the secret type to be `kubernetes.io/tls`




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
