### PR TITLE
Add ingress for rewriting Keycloak requests from /auth to /

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -7,7 +7,7 @@
       "name": "keycloak",
       "slug": "keycloak",
       "parameter_key": "keycloak",
-      "test_cases": "builtin external openshift openshift-postgres",
+      "test_cases": "builtin builtin-auth-rewrite external openshift openshift-auth-rewrite openshift-postgres",
       "add_lib": "n",
       "add_pp": "y",
       "add_golden": "y",

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,8 +33,10 @@ jobs:
       matrix:
         provider:
           - builtin
+          - builtin-auth-rewrite
           - external
           - openshift
+          - openshift-auth-rewrite
           - openshift-postgres
     defaults:
       run:
@@ -62,8 +64,10 @@ jobs:
       matrix:
         provider:
           - builtin
+          - builtin-auth-rewrite
           - external
           - openshift
+          - openshift-auth-rewrite
           - openshift-postgres
     defaults:
       run:

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -57,4 +57,4 @@ KUBENT_IMAGE    ?= ghcr.io/doitintl/kube-no-trouble:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 
 instance ?= builtin
-test_instances = tests/builtin.yml tests/external.yml tests/openshift.yml tests/openshift-postgres.yml
+test_instances = tests/builtin.yml tests/builtin-auth-rewrite.yml tests/external.yml tests/openshift.yml tests/openshift-auth-rewrite.yml tests/openshift-postgres.yml

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -112,6 +112,22 @@ parameters:
           cert: "?{vaultkv:${cluster:tenant}/${cluster:name}/${_instance}/ingress-cert}"
           certKey: "?{vaultkv:${cluster:tenant}/${cluster:name}/${_instance}/ingress-cert-key}"
 
+    # Rewriting /auth requests to /
+    # Used for a migration scanario meanwhile client configs may use /auth or / at the same time
+    # By rewriting the TLS content, passtrough is technically impossible, so not implemented
+    ingressAuthRewrite:
+      enabled: false
+      annotations:
+        nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+        nginx.ingress.kubernetes.io/proxy-buffer-size: 16k
+        nginx.ingress.kubernetes.io/use-regex: "true"
+        nginx.ingress.kubernetes.io/rewrite-target: /$2
+        route.openshift.io/termination: reencrypt
+        haproxy.router.openshift.io/rewrite-target: /
+      ingressClassName: null
+      tls:
+        secretName: ${keycloak:ingress:tls:secretName}
+
     route:
       enabled: false
 

--- a/class/keycloak.yml
+++ b/class/keycloak.yml
@@ -24,6 +24,10 @@ parameters:
           - keycloak/component/prometheus-netpol.jsonnet
         input_type: jsonnet
         output_path: ${_instance}
+      - input_paths:
+          - keycloak/component/auth-rewrite.jsonnet
+        input_type: jsonnet
+        output_path: ${_instance}
       - output_path: ${_instance}/01_keycloak_helmchart
         input_type: helm
         output_type: yaml

--- a/component/auth-rewrite.jsonnet
+++ b/component/auth-rewrite.jsonnet
@@ -1,0 +1,64 @@
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+local inv = kap.inventory();
+local params = inv.parameters.keycloak;
+
+local ingress_name = 'keycloakx-auth-rewrite';
+local keycloak_name = 'keycloakx';
+local ingress_class_name =
+  if params.ingressAuthRewrite.ingressClassName != null then
+    { ingressClassName: params.ingressAuthRewrite.ingressClassName }
+  else
+    {};
+local ingress_path =
+  if inv.parameters.facts.distribution == 'openshift4' then
+    '/auth'
+  else
+    '/auth(/|$)(.*)';
+
+local ingress =
+  kube.Ingress(ingress_name) {
+    metadata+: {
+      annotations: params.ingressAuthRewrite.annotations,
+      labels: params.labels,
+    },
+    spec+:
+      ingress_class_name
+      {
+        rules: [
+          {
+            host: params.fqdn,
+            http:
+              {
+                paths: [
+                  {
+                    path: ingress_path,
+                    pathType: 'Prefix',
+                    backend: {
+                      service: {
+                        name: keycloak_name + '-http',
+                        port: {
+                          name: params.helm_values.ingress.servicePort,
+                        },
+                      },
+                    },
+                  },
+                ],
+              },
+          },
+        ],
+        tls: [
+          {
+            hosts: [
+              params.fqdn,
+            ],
+            secretName: params.ingressAuthRewrite.tls.secretName,
+          },
+        ],
+
+      },
+  };
+
+{
+  [if params.ingressAuthRewrite.enabled then '20_ingress_auth_rewrite']: ingress,
+}

--- a/docs/modules/ROOT/pages/how-tos/change-relative-path.adoc
+++ b/docs/modules/ROOT/pages/how-tos/change-relative-path.adoc
@@ -1,0 +1,35 @@
+= Change relative path /auth to /
+
+The current default relativ path of Keycloak is `/`.
+Keycloak based on Quarkus
+
+[source,yaml]
+----
+parameters:
+  keycloak:
+    helm_values:
+      http:
+        # Default for Keycloak Quarkus
+        relativePath: "/"
+----
+
+== OpenID Connect Discovery
+
+Because of this change the well known openid configuration still shows the old path.
+
+```
+Original path: https://x.x.x.x/auth/realms/my_realm/.well-known/openid-configuration
+Ajusted path: https://x.x.x.x/realms/my_realm/.well-known/openid-configuration
+```
+
+The verification check does detect the different paths fail and prevent the login.
+
+```
+ERROR: Failed to initialise OAuth2 Proxy: error intiailising provider: could not create provider data: error building OIDC ProviderVerifier: could not get verifier builder: error while discovery OIDC configuration: oidc: issuer did not match the issuer returned by provider,
+```
+
+As a example for oauth2-proxy: To prevent the OIDC client does reject itself you can add the https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview/#command-line-options[parameter] to ignore the different paths:
+
+```
+--insecure-oidc-skip-issuer-verification
+```

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -381,6 +381,63 @@ type:: string
 default:: `?{vaultkv:${cluster:tenant}/${cluster:name}/${_instance}/ingress-cert-key}`
 
 
+=== `ingressAuthRewrite.enabled`
+
+[horizontal]
+type:: bool
+default:: `false`
+
+Creates an additional ingress object to rewrite all traffic from `/auth` to `/`.
+
+This is intended to be used for the migration from the realm path including `/auth` to the current Keycloak default of `/`.
+The clients can interact with Keycloak on both URLs.
+This allows a soft migration over time.
+
+
+[IMPORTANT]
+====
+Keycloak relative path MUST be set to `/` to be.
+
+
+[source,bash]
+----
+parameters:
+  keycloak:
+    helm_values:
+      http:
+        relativePath: "/"
+----
+
+====
+
+
+=== `ingressAuthRewrite.annotations`
+
+[horizontal]
+type:: dict
+default:: `{}`
+
+Annotations for the `/auth` rewrite ingrss object.
+
+
+== `ingressAuthRewrite.ingressClassName`
+
+[horizontal]
+type:: string
+default:: `null`
+
+IngressClassName for the `/auth` rewrite ingrss object.
+
+
+== `ingressAuthRewrite.tls.secretName`
+
+[horizontal]
+type:: string
+default:: `${keycloak:ingress:tls:secretName}`
+
+TLS secret name for the `/auth` rewrite ingrss object.
+
+
 == `route.enabled`
 
 [horizontal]

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -29,6 +29,7 @@
 * xref:how-tos/upgrade-14.x-to-15.x.adoc[Upgrade 14.x to 15.x]
 * xref:how-tos/openshift-4.adoc[Install on OpenShift 4]
 * xref:how-tos/pin-versions.adoc[Pin versions]
+* xref:how-tos/change-relative-path.adoc[Change relative path /auth to /]
 
 .Explanations
 * xref:explanations/default-features.adoc[Default features]

--- a/tests/builtin-auth-rewrite.yml
+++ b/tests/builtin-auth-rewrite.yml
@@ -1,0 +1,52 @@
+---
+applications:
+  - prometheus
+
+parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-prometheus/master/lib/prometheus.libsonnet
+        output_path: vendor/lib/prometheus.libsonnet
+
+  prometheus:
+    defaultInstance: monitoring
+
+  keycloak:
+    namespaceLabels:
+      test: testing
+    extraEnv:
+      FOO:
+        value: "bar"
+      KC_DB_URL_PORT:
+        value: "patched"
+    extraInitContainers:
+      theme-provider:
+        image: company/keycloak-theme:v1.0.0
+        imagePullPolicy: IfNotPresent
+        command:
+          - sh
+        args:
+          - -c
+          - |
+            echo "Copying theme..."
+            cp -R /theme/* /company-theme
+        volumeMounts:
+          - name: theme
+            mountPath: /company-theme
+    extraVolumes:
+      theme:
+        emptyDir: {}
+    extraVolumeMounts:
+      test:
+        name: theme
+        readOnly: true
+        mountPath: /opt/test
+    ingressAuthRewrite:
+      enabled: true
+    helm_values:
+      networkPolicy:
+        enabled: true
+      http:
+        # Default for Keycloak Quarkus
+        relativePath: "/"

--- a/tests/builtin-auth-rewrite/ingress_auth_reqrite_test.go
+++ b/tests/builtin-auth-rewrite/ingress_auth_reqrite_test.go
@@ -1,0 +1,21 @@
+package builtin_auth_rewrite
+
+import (
+	"testing"
+
+	"github.com/projectsyn/component-keycloak/common"
+	"github.com/stretchr/testify/assert"
+	networkingv1 "k8s.io/api/networking/v1"
+)
+
+var (
+	basePath = "../../compiled/builtin-auth-rewrite/builtin-auth-rewrite"
+	ingressPath = "/20_ingress_auth_rewrite.yaml"
+)
+
+func Test_IngressApiVersion(t *testing.T) {
+	subject := &networkingv1.Ingress{}
+	scheme := common.NewSchemeWithDefault(t)
+	ingress := common.DecodeWithSchema(t, basePath+ingressPath, subject, scheme).(*networkingv1.Ingress)
+	assert.Equal(t, "keycloakx-auth-rewrite", ingress.Name)
+}

--- a/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/apps/builtin-auth-rewrite.yaml
+++ b/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/apps/builtin-auth-rewrite.yaml
@@ -1,0 +1,6 @@
+spec:
+  ignoreDifferences:
+    - group: ''
+      jsonPointers:
+        - /imagePullSecrets
+      kind: ServiceAccount

--- a/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/00_namespace.yaml
+++ b/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/00_namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations: {}
+  labels:
+    monitoring.syn.tools/monitoring: 'true'
+    name: syn-builtin-auth-rewrite
+    test: testing
+  name: syn-builtin-auth-rewrite

--- a/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/01_keycloak_helmchart/keycloakx/templates/ingress.yaml
+++ b/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/01_keycloak_helmchart/keycloakx/templates/ingress.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+    route.openshift.io/termination: reencrypt
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: builtin-auth-rewrite
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/version: 22.0.5
+    helm.sh/chart: keycloakx-2.3.0
+  name: keycloakx
+  namespace: syn-builtin-auth-rewrite
+spec:
+  rules:
+    - host: keycloak.example.com
+      http:
+        paths:
+          - backend:
+              service:
+                name: keycloakx-http
+                port:
+                  name: https
+            path: /
+            pathType: Prefix
+  tls:
+    - hosts:
+        - keycloak.example.com
+      secretName: ingress-tls

--- a/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/01_keycloak_helmchart/keycloakx/templates/networkpolicy.yaml
+++ b/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/01_keycloak_helmchart/keycloakx/templates/networkpolicy.yaml
@@ -1,0 +1,41 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/instance: keycloakx
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloakx
+    app.kubernetes.io/version: 22.0.5
+    helm.sh/chart: keycloakx-2.3.0
+  name: keycloakx
+  namespace: syn-builtin-auth-rewrite
+spec:
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: ingress-nginx
+      ports:
+        - port: 8080
+          protocol: TCP
+        - port: 8443
+          protocol: TCP
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: keycloakx
+              app.kubernetes.io/name: keycloakx
+      ports:
+        - port: 8080
+          protocol: TCP
+        - port: 8443
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: keycloakx
+      app.kubernetes.io/name: keycloakx
+  policyTypes:
+    - Ingress

--- a/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/01_keycloak_helmchart/keycloakx/templates/prometheusrule.yaml
+++ b/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/01_keycloak_helmchart/keycloakx/templates/prometheusrule.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: builtin-auth-rewrite
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/version: 22.0.5
+    helm.sh/chart: keycloakx-2.3.0
+  name: keycloakx
+  namespace: syn-builtin-auth-rewrite
+spec:
+  groups:
+    - name: keycloakx
+      rules: []

--- a/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/01_keycloak_helmchart/keycloakx/templates/service-headless.yaml
+++ b/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/01_keycloak_helmchart/keycloakx/templates/service-headless.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: headless
+    app.kubernetes.io/instance: keycloakx
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloakx
+    app.kubernetes.io/version: 22.0.5
+    helm.sh/chart: keycloakx-2.3.0
+  name: keycloakx-headless
+  namespace: syn-builtin-auth-rewrite
+spec:
+  clusterIP: None
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: http
+  selector:
+    app.kubernetes.io/instance: keycloakx
+    app.kubernetes.io/name: keycloakx
+  type: ClusterIP

--- a/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/01_keycloak_helmchart/keycloakx/templates/service-http.yaml
+++ b/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/01_keycloak_helmchart/keycloakx/templates/service-http.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: http
+    app.kubernetes.io/instance: builtin-auth-rewrite
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/version: 22.0.5
+    helm.sh/chart: keycloakx-2.3.0
+  name: keycloakx-http
+  namespace: syn-builtin-auth-rewrite
+spec:
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: http
+    - name: https
+      port: 8443
+      protocol: TCP
+      targetPort: https
+  selector:
+    app.kubernetes.io/instance: keycloakx
+    app.kubernetes.io/name: keycloakx
+  type: ClusterIP

--- a/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/01_keycloak_helmchart/keycloakx/templates/serviceaccount.yaml
+++ b/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/01_keycloak_helmchart/keycloakx/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+automountServiceAccountToken: true
+imagePullSecrets: []
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: builtin-auth-rewrite
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/version: 22.0.5
+    helm.sh/chart: keycloakx-2.3.0
+  name: keycloakx
+  namespace: syn-builtin-auth-rewrite

--- a/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/01_keycloak_helmchart/keycloakx/templates/servicemonitor.yaml
+++ b/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/01_keycloak_helmchart/keycloakx/templates/servicemonitor.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: builtin-auth-rewrite
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/version: 22.0.5
+    helm.sh/chart: keycloakx-2.3.0
+  name: keycloakx-keycloakx
+  namespace: syn-builtin-auth-rewrite
+spec:
+  endpoints:
+    - interval: 10s
+      path: /metrics
+      port: http
+      scrapeTimeout: 10s
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: http
+      app.kubernetes.io/instance: keycloakx
+      app.kubernetes.io/name: keycloakx

--- a/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -1,0 +1,206 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: builtin-auth-rewrite
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/version: 22.0.5
+    helm.sh/chart: keycloakx-2.3.0
+  name: keycloakx
+  namespace: syn-builtin-auth-rewrite
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: keycloakx
+      app.kubernetes.io/name: keycloakx
+  serviceName: keycloakx-headless
+  template:
+    metadata:
+      annotations:
+        checksum/config-startup: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        checksum/secrets: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+      labels:
+        app.kubernetes.io/instance: keycloakx
+        app.kubernetes.io/name: keycloakx
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app.kubernetes.io/component
+                      operator: NotIn
+                      values:
+                        - test
+                  matchLabels:
+                    app.kubernetes.io/instance: keycloakx
+                    app.kubernetes.io/name: keycloakx
+                topologyKey: topology.kubernetes.io/zone
+              weight: 100
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: NotIn
+                    values:
+                      - test
+                matchLabels:
+                  app.kubernetes.io/instance: keycloakx
+                  app.kubernetes.io/name: keycloakx
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - args:
+            - start
+            - --http-enabled=true
+          env:
+            - name: FOO
+              value: bar
+            - name: JAVA_OPTS
+              value: -XX:MaxRAMPercentage=50.0 -Djgroups.dns.query=keycloakx-headless
+            - name: KC_CACHE
+              value: ispn
+            - name: KC_CACHE_STACK
+              value: kubernetes
+            - name: KC_DB
+              value: postgres
+            - name: KC_DB_URL_DATABASE
+              value: keycloak
+            - name: KC_DB_URL_HOST
+              value: keycloak-postgresql
+            - name: KC_DB_URL_PORT
+              value: patched
+            - name: KC_DB_USERNAME
+              value: keycloak
+            - name: KC_HEALTH_ENABLED
+              value: 'true'
+            - name: KC_HOSTNAME
+              value: keycloak.example.com
+            - name: KC_HOSTNAME_STRICT
+              value: 'false'
+            - name: KC_HTTPS_CERTIFICATE_FILE
+              value: /etc/x509/https/tls.crt
+            - name: KC_HTTPS_CERTIFICATE_KEY_FILE
+              value: /etc/x509/https/tls.key
+            - name: KC_HTTP_RELATIVE_PATH
+              value: /
+            - name: KC_METRICS_ENABLED
+              value: 'true'
+            - name: KC_PROXY
+              value: reencrypt
+          envFrom:
+            - secretRef:
+                name: keycloak-admin-user
+            - secretRef:
+                name: keycloak-postgresql
+          image: quay.io/keycloak/keycloak:22.0.5
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: http
+            initialDelaySeconds: 0
+            timeoutSeconds: 5
+          name: keycloak
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+            - containerPort: 8443
+              name: https
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: http
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: '1'
+              memory: 1Gi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+          startupProbe:
+            failureThreshold: 60
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /opt/keycloak/db-certs
+              name: db-certs
+              readOnly: true
+            - mountPath: /etc/x509/https
+              name: keycloak-tls
+              readOnly: true
+            - mountPath: /opt/test
+              name: theme
+              readOnly: true
+      enableServiceLinks: true
+      initContainers:
+        - command:
+            - sh
+            - -c
+            - "echo 'Waiting for Database to become ready...'\n\nuntil printf \".\"\
+              \ && nc -z -w 2 keycloak-postgresql 5432; do\n    sleep 2;\ndone;\n\n\
+              echo 'Database OK \u2713'\n"
+          image: docker.io/busybox:1.32
+          imagePullPolicy: IfNotPresent
+          name: dbchecker
+          resources:
+            limits:
+              cpu: 20m
+              memory: 32Mi
+            requests:
+              cpu: 20m
+              memory: 32Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+        - args:
+            - -c
+            - |
+              echo "Copying theme..."
+              cp -R /theme/* /company-theme
+          command:
+            - sh
+          image: company/keycloak-theme:v1.0.0
+          imagePullPolicy: IfNotPresent
+          name: theme-provider
+          volumeMounts:
+            - mountPath: /company-theme
+              name: theme
+      restartPolicy: Always
+      securityContext:
+        fsGroup: 1000
+      serviceAccountName: keycloakx
+      terminationGracePeriodSeconds: 60
+      volumes:
+        - name: db-certs
+          secret:
+            defaultMode: 256
+            items:
+              - key: tls.crt
+                path: tls.crt
+            secretName: keycloak-postgresql-tls
+        - name: keycloak-tls
+          secret:
+            defaultMode: 420
+            secretName: keycloak-tls
+        - emptyDir: {}
+          name: theme
+  updateStrategy:
+    type: RollingUpdate

--- a/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/01_keycloak_helmchart/postgresql/templates/primary/networkpolicy.yaml
+++ b/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/01_keycloak_helmchart/postgresql/templates/primary/networkpolicy.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/component: primary
+    app.kubernetes.io/instance: keycloak
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/version: 15.4.0
+    helm.sh/chart: postgresql-12.12.10
+  name: keycloak-postgresql-ingress
+  namespace: syn-builtin-auth-rewrite
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: keycloakx
+              app.kubernetes.io/name: keycloakx
+      ports:
+        - port: 5432
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: primary
+      app.kubernetes.io/instance: keycloak
+      app.kubernetes.io/name: postgresql

--- a/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/01_keycloak_helmchart/postgresql/templates/primary/statefulset.yaml
+++ b/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/01_keycloak_helmchart/postgresql/templates/primary/statefulset.yaml
@@ -1,0 +1,211 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/component: primary
+    app.kubernetes.io/instance: builtin-auth-rewrite
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/version: 15.4.0
+    helm.sh/chart: postgresql-12.12.10
+  name: keycloak-postgresql
+  namespace: syn-builtin-auth-rewrite
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: primary
+      app.kubernetes.io/instance: keycloak
+      app.kubernetes.io/name: postgresql
+  serviceName: keycloak-postgresql-hl
+  template:
+    metadata:
+      annotations:
+        k8up.io/backupcommand: sh -c 'PGDATABASE="$POSTGRES_DATABASE" PGUSER="$POSTGRES_USER"
+          PGPASSWORD="$POSTGRES_PASSWORD" pg_dump --clean'
+        k8up.io/file-extension: .sql
+      labels:
+        app.kubernetes.io/component: primary
+        app.kubernetes.io/instance: keycloak
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: postgresql
+        app.kubernetes.io/version: 15.4.0
+        helm.sh/chart: postgresql-12.12.10
+      name: keycloak-postgresql
+    spec:
+      affinity:
+        nodeAffinity: null
+        podAffinity: null
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/component: primary
+                    app.kubernetes.io/instance: keycloak
+                    app.kubernetes.io/name: postgresql
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+      containers:
+        - env:
+            - name: BITNAMI_DEBUG
+              value: 'false'
+            - name: POSTGRESQL_PORT_NUMBER
+              value: '5432'
+            - name: POSTGRESQL_VOLUME_DIR
+              value: /bitnami/postgresql
+            - name: PGDATA
+              value: /bitnami/postgresql/data
+            - name: POSTGRES_USER
+              value: keycloak
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: keycloak-postgresql
+            - name: POSTGRES_POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: postgres-password
+                  name: keycloak-postgresql
+            - name: POSTGRES_DATABASE
+              value: keycloak
+            - name: POSTGRESQL_ENABLE_LDAP
+              value: 'no'
+            - name: POSTGRESQL_ENABLE_TLS
+              value: 'yes'
+            - name: POSTGRESQL_TLS_PREFER_SERVER_CIPHERS
+              value: 'yes'
+            - name: POSTGRESQL_TLS_CERT_FILE
+              value: /opt/bitnami/postgresql/certs/tls.crt
+            - name: POSTGRESQL_TLS_KEY_FILE
+              value: /opt/bitnami/postgresql/certs/tls.key
+            - name: POSTGRESQL_LOG_HOSTNAME
+              value: 'false'
+            - name: POSTGRESQL_LOG_CONNECTIONS
+              value: 'false'
+            - name: POSTGRESQL_LOG_DISCONNECTIONS
+              value: 'false'
+            - name: POSTGRESQL_PGAUDIT_LOG_CATALOG
+              value: 'off'
+            - name: POSTGRESQL_CLIENT_MIN_MESSAGES
+              value: error
+            - name: POSTGRESQL_SHARED_PRELOAD_LIBRARIES
+              value: pgaudit
+          image: docker.io/bitnami/postgresql:15.6.0-debian-12-r5
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "keycloak" -d "dbname=keycloak" -h 127.0.0.1
+                  -p 5432
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: postgresql
+          ports:
+            - containerPort: 5432
+              name: tcp-postgresql
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - -e
+                - |
+                  exec pg_isready -U "keycloak" -d "dbname=keycloak sslcert=/opt/bitnami/postgresql/certs/tls.crt sslkey=/opt/bitnami/postgresql/certs/tls.key" -h 127.0.0.1 -p 5432
+                  [ -f /opt/bitnami/postgresql/tmp/.initialized ] || [ -f /bitnami/postgresql/.initialized ]
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources:
+            limits: {}
+            requests:
+              cpu: 250m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /opt/bitnami/postgresql/certs
+              name: postgresql-certificates
+              readOnly: true
+            - mountPath: /dev/shm
+              name: dshm
+            - mountPath: /bitnami/postgresql
+              name: data
+      hostIPC: false
+      hostNetwork: false
+      initContainers:
+        - command:
+            - /bin/sh
+            - -ec
+            - |
+              chown 1001:1001 /bitnami/postgresql
+              mkdir -p /bitnami/postgresql/data
+              chmod 700 /bitnami/postgresql/data
+              find /bitnami/postgresql -mindepth 1 -maxdepth 1 -not -name "conf" -not -name ".snapshot" -not -name "lost+found" | \
+                xargs -r chown -R 1001:1001
+              chmod -R 777 /dev/shm
+              cp /tmp/certs/* /opt/bitnami/postgresql/certs/
+              chown -R 1001:1001 /opt/bitnami/postgresql/certs/
+              chmod 600 /opt/bitnami/postgresql/certs/tls.key
+          image: docker.io/bitnami/os-shell:11-debian-11-r93
+          imagePullPolicy: IfNotPresent
+          name: init-chmod-data
+          resources:
+            limits: {}
+            requests: {}
+          securityContext:
+            runAsGroup: 0
+            runAsNonRoot: false
+            runAsUser: 0
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /bitnami/postgresql
+              name: data
+            - mountPath: /dev/shm
+              name: dshm
+            - mountPath: /tmp/certs
+              name: raw-certificates
+            - mountPath: /opt/bitnami/postgresql/certs
+              name: postgresql-certificates
+      securityContext:
+        fsGroup: 1001
+      serviceAccountName: default
+      volumes:
+        - name: raw-certificates
+          secret:
+            secretName: keycloak-postgresql-tls
+        - emptyDir: {}
+          name: postgresql-certificates
+        - emptyDir:
+            medium: Memory
+          name: dshm
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 8Gi

--- a/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/01_keycloak_helmchart/postgresql/templates/primary/svc-headless.yaml
+++ b/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/01_keycloak_helmchart/postgresql/templates/primary/svc-headless.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: 'true'
+  labels:
+    app.kubernetes.io/component: primary
+    app.kubernetes.io/instance: keycloak
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/version: 15.4.0
+    helm.sh/chart: postgresql-12.12.10
+  name: keycloak-postgresql-hl
+  namespace: syn-builtin-auth-rewrite
+spec:
+  clusterIP: None
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/component: primary
+    app.kubernetes.io/instance: keycloak
+    app.kubernetes.io/name: postgresql
+  type: ClusterIP

--- a/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/01_keycloak_helmchart/postgresql/templates/primary/svc.yaml
+++ b/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/01_keycloak_helmchart/postgresql/templates/primary/svc.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: primary
+    app.kubernetes.io/instance: keycloak
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/version: 15.4.0
+    helm.sh/chart: postgresql-12.12.10
+  name: keycloak-postgresql
+  namespace: syn-builtin-auth-rewrite
+spec:
+  ports:
+    - name: tcp-postgresql
+      nodePort: null
+      port: 5432
+      targetPort: tcp-postgresql
+  selector:
+    app.kubernetes.io/component: primary
+    app.kubernetes.io/instance: keycloak
+    app.kubernetes.io/name: postgresql
+  sessionAffinity: None
+  type: ClusterIP

--- a/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/01_networkpolicy_infinispan.yaml
+++ b/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/01_networkpolicy_infinispan.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: builtin-auth-rewrite
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    name: keycloakx-infinispan
+  name: keycloakx-infinispan
+spec:
+  egress: []
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: keycloakx
+              app.kubernetes.io/name: keycloakx
+      ports:
+        - port: 7800
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: keycloakx
+      app.kubernetes.io/name: keycloakx
+  policyTypes:
+    - Ingress

--- a/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/10_admin_secret.yaml
+++ b/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/10_admin_secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: builtin-auth-rewrite
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    name: keycloak-admin-user
+  name: keycloak-admin-user
+stringData:
+  KEYCLOAK_ADMIN: admin
+  KEYCLOAK_ADMIN_PASSWORD: t-silent-test-1234/c-green-test-1234/builtin-auth-rewrite/admin-password
+type: Opaque

--- a/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/11_db_secret.yaml
+++ b/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/11_db_secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: builtin-auth-rewrite
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    name: keycloak-postgresql
+  name: keycloak-postgresql
+stringData:
+  JDBC_PARAMS: sslmode=verify-ca&sslrootcert=/opt/keycloak/db-certs/tls.crt
+  KC_DB_PASSWORD: t-silent-test-1234/c-green-test-1234/builtin-auth-rewrite/db-password
+  password: t-silent-test-1234/c-green-test-1234/builtin-auth-rewrite/db-password
+  postgres-password: t-silent-test-1234/c-green-test-1234/builtin-auth-rewrite/db-password
+type: Opaque

--- a/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/12_db_certs.yaml
+++ b/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/12_db_certs.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: builtin-auth-rewrite
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    name: keycloak-postgresql-tls
+  name: keycloak-postgresql-tls
+stringData:
+  tls.crt: t-silent-test-1234/c-green-test-1234/builtin-auth-rewrite/server-cert
+  tls.key: t-silent-test-1234/c-green-test-1234/builtin-auth-rewrite/server-cert-key
+type: Opaque

--- a/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/13_keycloak_certs.yaml
+++ b/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/13_keycloak_certs.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: builtin-auth-rewrite
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    name: keycloak-tls
+  name: keycloak-tls
+stringData:
+  ca.crt: t-silent-test-1234/c-green-test-1234/builtin-auth-rewrite/keycloak-cert
+  tls.crt: t-silent-test-1234/c-green-test-1234/builtin-auth-rewrite/keycloak-cert
+  tls.key: t-silent-test-1234/c-green-test-1234/builtin-auth-rewrite/keycloak-cert-key
+type: Opaque

--- a/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/20_ingress_auth_rewrite.yaml
+++ b/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/20_ingress_auth_rewrite.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    haproxy.router.openshift.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 16k
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/use-regex: 'true'
+    route.openshift.io/termination: reencrypt
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: builtin-auth-rewrite
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+  name: keycloakx-auth-rewrite
+spec:
+  rules:
+    - host: keycloak.example.com
+      http:
+        paths:
+          - backend:
+              service:
+                name: keycloakx-http
+                port:
+                  name: https
+            path: /auth(/|$)(.*)
+            pathType: Prefix
+  tls:
+    - hosts:
+        - keycloak.example.com
+      secretName: ingress-tls

--- a/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/40_netpol.yaml
+++ b/tests/golden/builtin-auth-rewrite/builtin-auth-rewrite/builtin-auth-rewrite/40_netpol.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: prometheus-syn-infra-monitoring-to-keycloakx
+  name: prometheus-syn-infra-monitoring-to-keycloakx
+  namespace: syn-builtin-auth-rewrite
+spec:
+  egress: []
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: syn-infra-monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: prometheus
+      ports:
+        - port: 8080
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: keycloakx
+      app.kubernetes.io/name: keycloakx
+  policyTypes:
+    - Ingress

--- a/tests/golden/openshift-auth-rewrite/openshift-auth-rewrite/apps/openshift-auth-rewrite.yaml
+++ b/tests/golden/openshift-auth-rewrite/openshift-auth-rewrite/apps/openshift-auth-rewrite.yaml
@@ -1,0 +1,6 @@
+spec:
+  ignoreDifferences:
+    - group: ''
+      jsonPointers:
+        - /imagePullSecrets
+      kind: ServiceAccount

--- a/tests/golden/openshift-auth-rewrite/openshift-auth-rewrite/openshift-auth-rewrite/00_namespace.yaml
+++ b/tests/golden/openshift-auth-rewrite/openshift-auth-rewrite/openshift-auth-rewrite/00_namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations: {}
+  labels:
+    name: keycloak-dev
+    openshift.io/cluster-monitoring: 'true'
+  name: keycloak-dev

--- a/tests/golden/openshift-auth-rewrite/openshift-auth-rewrite/openshift-auth-rewrite/01_keycloak_helmchart/keycloakx/templates/ingress.yaml
+++ b/tests/golden/openshift-auth-rewrite/openshift-auth-rewrite/openshift-auth-rewrite/01_keycloak_helmchart/keycloakx/templates/ingress.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+    route.openshift.io/termination: reencrypt
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: openshift-auth-rewrite
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/version: 22.0.5
+    helm.sh/chart: keycloakx-2.3.0
+  name: keycloakx
+  namespace: keycloak-dev
+spec:
+  rules:
+    - host: keycloak.example.com
+      http:
+        paths:
+          - backend:
+              service:
+                name: keycloakx-http
+                port:
+                  name: https
+            path: /
+            pathType: Prefix
+  tls:
+    - hosts:
+        - keycloak.example.com
+      secretName: ingress-tls

--- a/tests/golden/openshift-auth-rewrite/openshift-auth-rewrite/openshift-auth-rewrite/01_keycloak_helmchart/keycloakx/templates/prometheusrule.yaml
+++ b/tests/golden/openshift-auth-rewrite/openshift-auth-rewrite/openshift-auth-rewrite/01_keycloak_helmchart/keycloakx/templates/prometheusrule.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: openshift-auth-rewrite
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/version: 22.0.5
+    helm.sh/chart: keycloakx-2.3.0
+  name: keycloakx
+  namespace: keycloak-dev
+spec:
+  groups:
+    - name: keycloakx
+      rules: []

--- a/tests/golden/openshift-auth-rewrite/openshift-auth-rewrite/openshift-auth-rewrite/01_keycloak_helmchart/keycloakx/templates/service-headless.yaml
+++ b/tests/golden/openshift-auth-rewrite/openshift-auth-rewrite/openshift-auth-rewrite/01_keycloak_helmchart/keycloakx/templates/service-headless.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: headless
+    app.kubernetes.io/instance: keycloakx
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloakx
+    app.kubernetes.io/version: 22.0.5
+    helm.sh/chart: keycloakx-2.3.0
+  name: keycloakx-headless
+  namespace: keycloak-dev
+spec:
+  clusterIP: None
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: http
+  selector:
+    app.kubernetes.io/instance: keycloakx
+    app.kubernetes.io/name: keycloakx
+  type: ClusterIP

--- a/tests/golden/openshift-auth-rewrite/openshift-auth-rewrite/openshift-auth-rewrite/01_keycloak_helmchart/keycloakx/templates/service-http.yaml
+++ b/tests/golden/openshift-auth-rewrite/openshift-auth-rewrite/openshift-auth-rewrite/01_keycloak_helmchart/keycloakx/templates/service-http.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: keycloak-tls
+  labels:
+    app.kubernetes.io/component: http
+    app.kubernetes.io/instance: openshift-auth-rewrite
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/version: 22.0.5
+    helm.sh/chart: keycloakx-2.3.0
+  name: keycloakx-http
+  namespace: keycloak-dev
+spec:
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: http
+    - name: https
+      port: 8443
+      protocol: TCP
+      targetPort: https
+  selector:
+    app.kubernetes.io/instance: keycloakx
+    app.kubernetes.io/name: keycloakx
+  type: ClusterIP

--- a/tests/golden/openshift-auth-rewrite/openshift-auth-rewrite/openshift-auth-rewrite/01_keycloak_helmchart/keycloakx/templates/serviceaccount.yaml
+++ b/tests/golden/openshift-auth-rewrite/openshift-auth-rewrite/openshift-auth-rewrite/01_keycloak_helmchart/keycloakx/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+automountServiceAccountToken: true
+imagePullSecrets: []
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: openshift-auth-rewrite
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/version: 22.0.5
+    helm.sh/chart: keycloakx-2.3.0
+  name: keycloakx
+  namespace: keycloak-dev

--- a/tests/golden/openshift-auth-rewrite/openshift-auth-rewrite/openshift-auth-rewrite/01_keycloak_helmchart/keycloakx/templates/servicemonitor.yaml
+++ b/tests/golden/openshift-auth-rewrite/openshift-auth-rewrite/openshift-auth-rewrite/01_keycloak_helmchart/keycloakx/templates/servicemonitor.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: openshift-auth-rewrite
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/version: 22.0.5
+    helm.sh/chart: keycloakx-2.3.0
+  name: keycloakx-keycloakx
+  namespace: keycloak-dev
+spec:
+  endpoints:
+    - interval: 10s
+      path: /metrics
+      port: http
+      scrapeTimeout: 10s
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: http
+      app.kubernetes.io/instance: keycloakx
+      app.kubernetes.io/name: keycloakx

--- a/tests/golden/openshift-auth-rewrite/openshift-auth-rewrite/openshift-auth-rewrite/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/openshift-auth-rewrite/openshift-auth-rewrite/openshift-auth-rewrite/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -1,0 +1,214 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: openshift-auth-rewrite
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/version: 22.0.5
+    helm.sh/chart: keycloakx-2.3.0
+  name: keycloakx
+  namespace: keycloak-dev
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: keycloakx
+      app.kubernetes.io/name: keycloakx
+  serviceName: keycloakx-headless
+  template:
+    metadata:
+      annotations:
+        checksum/config-startup: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        checksum/secrets: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+      labels:
+        app.kubernetes.io/instance: keycloakx
+        app.kubernetes.io/name: keycloakx
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app.kubernetes.io/component
+                      operator: NotIn
+                      values:
+                        - test
+                  matchLabels:
+                    app.kubernetes.io/instance: keycloakx
+                    app.kubernetes.io/name: keycloakx
+                topologyKey: topology.kubernetes.io/zone
+              weight: 100
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: NotIn
+                    values:
+                      - test
+                matchLabels:
+                  app.kubernetes.io/instance: keycloakx
+                  app.kubernetes.io/name: keycloakx
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - args:
+            - start
+            - --http-enabled=true
+          env:
+            - name: JAVA_OPTS
+              value: -XX:MaxRAMPercentage=50.0 -Djgroups.dns.query=keycloakx-headless
+            - name: KC_CACHE
+              value: ispn
+            - name: KC_CACHE_STACK
+              value: kubernetes
+            - name: KC_DB
+              value: mariadb
+            - name: KC_DB_URL_DATABASE
+              value: keycloak_dev
+            - name: KC_DB_URL_HOST
+              value: maxscale-masteronly
+            - name: KC_DB_URL_PORT
+              value: '3306'
+            - name: KC_DB_USERNAME
+              value: keycloak_dev
+            - name: KC_HEALTH_ENABLED
+              value: 'true'
+            - name: KC_HOSTNAME
+              value: keycloak.example.com
+            - name: KC_HOSTNAME_STRICT
+              value: 'false'
+            - name: KC_HTTPS_CERTIFICATE_FILE
+              value: /etc/x509/https/tls.crt
+            - name: KC_HTTPS_CERTIFICATE_KEY_FILE
+              value: /etc/x509/https/tls.key
+            - name: KC_HTTP_RELATIVE_PATH
+              value: /
+            - name: KC_METRICS_ENABLED
+              value: 'true'
+            - name: KC_PROXY
+              value: reencrypt
+          envFrom:
+            - secretRef:
+                name: keycloak-admin-user
+            - secretRef:
+                name: keycloak-postgresql
+          image: quay.io/keycloak/keycloak:22.0.5
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: http
+            initialDelaySeconds: 0
+            timeoutSeconds: 5
+          name: keycloak
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+            - containerPort: 8443
+              name: https
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: http
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: '1'
+              memory: 1Gi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          securityContext: null
+          startupProbe:
+            failureThreshold: 60
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /opt/keycloak/db-certs
+              name: db-certs
+              readOnly: true
+            - mountPath: /etc/x509/https
+              name: keycloak-tls
+              readOnly: true
+            - mountPath: /opt/keycloak/themes/app1
+              name: themes
+              subPath: app1
+            - mountPath: /opt/keycloak/themes/app2
+              name: themes
+              subPath: app2
+            - mountPath: /opt/keycloak/themes/customer
+              name: themes
+              subPath: customer
+            - mountPath: /opt/keycloak/themes/dev-app1
+              name: themes
+              subPath: dev-app1
+            - mountPath: /opt/keycloak/themes/dev-app2
+              name: themes
+              subPath: dev-app2
+            - mountPath: /opt/keycloak/themes/int-app1
+              name: themes
+              subPath: int-app1
+            - mountPath: /opt/keycloak/themes/int-app2
+              name: themes
+              subPath: int-app2
+      enableServiceLinks: true
+      initContainers:
+        - command:
+            - sh
+            - -c
+            - "echo 'Waiting for Database to become ready...'\n\nuntil printf \".\"\
+              \ && nc -z -w 2 maxscale-masteronly 3306; do\n    sleep 2;\ndone;\n\n\
+              echo 'Database OK \u2713'\n"
+          image: docker.io/busybox:1.32
+          imagePullPolicy: IfNotPresent
+          name: dbchecker
+          resources:
+            limits:
+              cpu: 20m
+              memory: 32Mi
+            requests:
+              cpu: 20m
+              memory: 32Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+        - args:
+            - -c
+            - |
+              echo "Copying theme..."
+              cp -Rv /themes/* /target/
+          command:
+            - sh
+          image: image-registry.openshift-image-registry.svc:5000/builds/customer-keycloak-theme:dev
+          imagePullPolicy: Always
+          name: theme-provider
+          volumeMounts:
+            - mountPath: /target
+              name: themes
+      restartPolicy: Always
+      securityContext: null
+      serviceAccountName: keycloakx
+      terminationGracePeriodSeconds: 60
+      volumes:
+        - emptyDir: {}
+          name: db-certs
+        - name: keycloak-tls
+          secret:
+            defaultMode: 420
+            secretName: keycloak-tls
+        - emptyDir: {}
+          name: themes
+  updateStrategy:
+    type: RollingUpdate

--- a/tests/golden/openshift-auth-rewrite/openshift-auth-rewrite/openshift-auth-rewrite/10_admin_secret.yaml
+++ b/tests/golden/openshift-auth-rewrite/openshift-auth-rewrite/openshift-auth-rewrite/10_admin_secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: openshift-auth-rewrite
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    name: keycloak-admin-user
+  name: keycloak-admin-user
+stringData:
+  KEYCLOAK_ADMIN: t-silent-test-1234/c-green-test-1234/openshift-auth-rewrite/admin-username
+  KEYCLOAK_ADMIN_PASSWORD: t-silent-test-1234/c-green-test-1234/openshift-auth-rewrite/admin-password
+type: Opaque

--- a/tests/golden/openshift-auth-rewrite/openshift-auth-rewrite/openshift-auth-rewrite/11_db_secret.yaml
+++ b/tests/golden/openshift-auth-rewrite/openshift-auth-rewrite/openshift-auth-rewrite/11_db_secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: openshift-auth-rewrite
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+    name: keycloak-postgresql
+  name: keycloak-postgresql
+stringData:
+  JDBC_PARAMS: sslmode=verify-ca&sslrootcert=/opt/keycloak/db-certs/tls.crt
+  KC_DB_PASSWORD: t-silent-test-1234/c-green-test-1234/openshift-auth-rewrite/db-password
+type: Opaque

--- a/tests/golden/openshift-auth-rewrite/openshift-auth-rewrite/openshift-auth-rewrite/20_ingress_auth_rewrite.yaml
+++ b/tests/golden/openshift-auth-rewrite/openshift-auth-rewrite/openshift-auth-rewrite/20_ingress_auth_rewrite.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    haproxy.router.openshift.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 16k
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/use-regex: 'true'
+    route.openshift.io/termination: reencrypt
+  labels:
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/instance: openshift-auth-rewrite
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: keycloak
+  name: keycloakx-auth-rewrite
+spec:
+  rules:
+    - host: keycloak.example.com
+      http:
+        paths:
+          - backend:
+              service:
+                name: keycloakx-http
+                port:
+                  name: https
+            path: /auth
+            pathType: Prefix
+  tls:
+    - hosts:
+        - keycloak.example.com
+      secretName: ingress-tls

--- a/tests/openshift-auth-rewrite.yml
+++ b/tests/openshift-auth-rewrite.yml
@@ -1,0 +1,87 @@
+---
+parameters:
+  facts:
+    distribution: openshift4
+
+  keycloak:
+    namespace: keycloak-dev
+    tls:
+      provider: openshift
+    admin:
+      username: "?{vaultkv:${cluster:tenant}/${cluster:name}/${_instance}/admin-username}"
+      password: "?{vaultkv:${cluster:tenant}/${cluster:name}/${_instance}/admin-password}"
+
+    ingressAuthRewrite:
+      enabled: true
+
+    helm_values:
+      podSecurityContext: null
+      securityContext: null
+      pgchecker:
+        securityContext: null
+      http:
+        # Default for Keycloak Quarkus
+        relativePath: "/"
+
+    database:
+      database: keycloak_dev
+      username: keycloak_dev
+      provider: external
+      tls:
+        enabled: false
+      external:
+        host: maxscale-masteronly
+        vendor: mariadb
+        port: 3306
+
+    extraVolumes:
+      themes:
+        emptyDir: {}
+      # overwrite the default that mounts a secret
+      db-certs:
+        emptyDir: {}
+
+    extraInitContainers:
+      theme-provider:
+        image: image-registry.openshift-image-registry.svc:5000/builds/customer-keycloak-theme:dev
+        imagePullPolicy: Always
+        command:
+          - sh
+        args:
+          - -c
+          - |
+            echo "Copying theme..."
+            cp -Rv /themes/* /target/
+        volumeMounts:
+          - name: themes
+            mountPath: /target
+
+    extraVolumeMounts:
+      theme-customer:
+        name: themes
+        mountPath: /opt/keycloak/themes/customer
+        subPath: customer
+      theme-app1:
+        name: themes
+        mountPath: /opt/keycloak/themes/app1
+        subPath: app1
+      theme-app2:
+        name: themes
+        mountPath: /opt/keycloak/themes/app2
+        subPath: app2
+      theme-int-app1:
+        name: themes
+        mountPath: /opt/keycloak/themes/int-app1
+        subPath: int-app1
+      theme-int-app2:
+        name: themes
+        mountPath: /opt/keycloak/themes/int-app2
+        subPath: int-app2
+      theme-dev-app1:
+        name: themes
+        mountPath: /opt/keycloak/themes/dev-app1
+        subPath: dev-app1
+      theme-dev-app2:
+        name: themes
+        mountPath: /opt/keycloak/themes/dev-app2
+        subPath: dev-app2

--- a/tests/openshift-auth-rewrite/ingress_auth_reqrite_test.go
+++ b/tests/openshift-auth-rewrite/ingress_auth_reqrite_test.go
@@ -1,0 +1,21 @@
+package openshift_auth_rewrite
+
+import (
+	"testing"
+
+	"github.com/projectsyn/component-keycloak/common"
+	"github.com/stretchr/testify/assert"
+	networkingv1 "k8s.io/api/networking/v1"
+)
+
+var (
+	basePath = "../../compiled/openshift-auth-rewrite/openshift-auth-rewrite"
+	ingressPath = "/20_ingress_auth_rewrite.yaml"
+)
+
+func Test_IngressApiVersion(t *testing.T) {
+	subject := &networkingv1.Ingress{}
+	scheme := common.NewSchemeWithDefault(t)
+	ingress := common.DecodeWithSchema(t, basePath+ingressPath, subject, scheme).(*networkingv1.Ingress)
+	assert.Equal(t, "keycloakx-auth-rewrite", ingress.Name)
+}


### PR DESCRIPTION
Keycloak based on Wilfly had a default relativ path of /auth. Since the migration to Quarkus this would be / by default. Existing clients can not be migrated in a big bang scenario.

This adds the capability to serve the Keycloak requests on / and /auth at the same time. NGNIX-Ingress and OpenShift has been tested.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

