### PR TITLE
Upgrade Keycloakx Helm Chart to v2.2.2

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -59,7 +59,7 @@ parameters:
     charts:
       keycloakx:
         source: https://codecentric.github.io/helm-charts
-        version: v2.2.1
+        version: v2.2.2
       postgresql:
         source: https://charts.bitnami.com/bitnami
         version: v12.5.6

--- a/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/ingress.yaml
+++ b/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
     app.kubernetes.io/version: 20.0.3
-    helm.sh/chart: keycloakx-2.2.1
+    helm.sh/chart: keycloakx-2.2.2
   name: keycloakx
   namespace: syn-builtin
 spec:

--- a/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/networkpolicy.yaml
+++ b/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/networkpolicy.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloakx
     app.kubernetes.io/version: 20.0.3
-    helm.sh/chart: keycloakx-2.2.1
+    helm.sh/chart: keycloakx-2.2.2
   name: keycloakx
   namespace: syn-builtin
 spec:

--- a/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/prometheusrule.yaml
+++ b/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/prometheusrule.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
     app.kubernetes.io/version: 20.0.3
-    helm.sh/chart: keycloakx-2.2.1
+    helm.sh/chart: keycloakx-2.2.2
   name: keycloakx
   namespace: syn-builtin
 spec:

--- a/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/service-headless.yaml
+++ b/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/service-headless.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloakx
     app.kubernetes.io/version: 20.0.3
-    helm.sh/chart: keycloakx-2.2.1
+    helm.sh/chart: keycloakx-2.2.2
   name: keycloakx-headless
   namespace: syn-builtin
 spec:

--- a/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/service-http.yaml
+++ b/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/service-http.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
     app.kubernetes.io/version: 20.0.3
-    helm.sh/chart: keycloakx-2.2.1
+    helm.sh/chart: keycloakx-2.2.2
   name: keycloakx-http
   namespace: syn-builtin
 spec:

--- a/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/serviceaccount.yaml
+++ b/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/serviceaccount.yaml
@@ -9,6 +9,6 @@ metadata:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
     app.kubernetes.io/version: 20.0.3
-    helm.sh/chart: keycloakx-2.2.1
+    helm.sh/chart: keycloakx-2.2.2
   name: keycloakx
   namespace: syn-builtin

--- a/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/servicemonitor.yaml
+++ b/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
     app.kubernetes.io/version: 20.0.3
-    helm.sh/chart: keycloakx-2.2.1
+    helm.sh/chart: keycloakx-2.2.2
   name: keycloakx-keycloakx
   namespace: syn-builtin
 spec:

--- a/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
     app.kubernetes.io/version: 20.0.3
-    helm.sh/chart: keycloakx-2.2.1
+    helm.sh/chart: keycloakx-2.2.2
   name: keycloakx
   namespace: syn-builtin
 spec:

--- a/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/ingress.yaml
+++ b/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
     app.kubernetes.io/version: 20.0.3
-    helm.sh/chart: keycloakx-2.2.1
+    helm.sh/chart: keycloakx-2.2.2
   name: keycloakx
   namespace: syn-external
 spec:

--- a/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/prometheusrule.yaml
+++ b/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/prometheusrule.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
     app.kubernetes.io/version: 20.0.3
-    helm.sh/chart: keycloakx-2.2.1
+    helm.sh/chart: keycloakx-2.2.2
   name: keycloakx
   namespace: syn-external
 spec:

--- a/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/service-headless.yaml
+++ b/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/service-headless.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloakx
     app.kubernetes.io/version: 20.0.3
-    helm.sh/chart: keycloakx-2.2.1
+    helm.sh/chart: keycloakx-2.2.2
   name: keycloakx-headless
   namespace: syn-external
 spec:

--- a/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/service-http.yaml
+++ b/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/service-http.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
     app.kubernetes.io/version: 20.0.3
-    helm.sh/chart: keycloakx-2.2.1
+    helm.sh/chart: keycloakx-2.2.2
   name: keycloakx-http
   namespace: syn-external
 spec:

--- a/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/serviceaccount.yaml
+++ b/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/serviceaccount.yaml
@@ -9,6 +9,6 @@ metadata:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
     app.kubernetes.io/version: 20.0.3
-    helm.sh/chart: keycloakx-2.2.1
+    helm.sh/chart: keycloakx-2.2.2
   name: keycloakx
   namespace: syn-external

--- a/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/servicemonitor.yaml
+++ b/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
     app.kubernetes.io/version: 20.0.3
-    helm.sh/chart: keycloakx-2.2.1
+    helm.sh/chart: keycloakx-2.2.2
   name: keycloakx-keycloakx
   namespace: syn-external
 spec:

--- a/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
     app.kubernetes.io/version: 20.0.3
-    helm.sh/chart: keycloakx-2.2.1
+    helm.sh/chart: keycloakx-2.2.2
   name: keycloakx
   namespace: syn-external
 spec:

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/ingress.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
     app.kubernetes.io/version: 20.0.3
-    helm.sh/chart: keycloakx-2.2.1
+    helm.sh/chart: keycloakx-2.2.2
   name: keycloakx
   namespace: syn-openshift-postgres
 spec:

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/prometheusrule.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/prometheusrule.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
     app.kubernetes.io/version: 20.0.3
-    helm.sh/chart: keycloakx-2.2.1
+    helm.sh/chart: keycloakx-2.2.2
   name: keycloakx
   namespace: syn-openshift-postgres
 spec:

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/service-headless.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/service-headless.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloakx
     app.kubernetes.io/version: 20.0.3
-    helm.sh/chart: keycloakx-2.2.1
+    helm.sh/chart: keycloakx-2.2.2
   name: keycloakx-headless
   namespace: syn-openshift-postgres
 spec:

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/service-http.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/service-http.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
     app.kubernetes.io/version: 20.0.3
-    helm.sh/chart: keycloakx-2.2.1
+    helm.sh/chart: keycloakx-2.2.2
   name: keycloakx-http
   namespace: syn-openshift-postgres
 spec:

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/serviceaccount.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/serviceaccount.yaml
@@ -9,6 +9,6 @@ metadata:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
     app.kubernetes.io/version: 20.0.3
-    helm.sh/chart: keycloakx-2.2.1
+    helm.sh/chart: keycloakx-2.2.2
   name: keycloakx
   namespace: syn-openshift-postgres

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/servicemonitor.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
     app.kubernetes.io/version: 20.0.3
-    helm.sh/chart: keycloakx-2.2.1
+    helm.sh/chart: keycloakx-2.2.2
   name: keycloakx-keycloakx
   namespace: syn-openshift-postgres
 spec:

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
     app.kubernetes.io/version: 20.0.3
-    helm.sh/chart: keycloakx-2.2.1
+    helm.sh/chart: keycloakx-2.2.2
   name: keycloakx
   namespace: syn-openshift-postgres
 spec:

--- a/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/ingress.yaml
+++ b/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
     app.kubernetes.io/version: 20.0.3
-    helm.sh/chart: keycloakx-2.2.1
+    helm.sh/chart: keycloakx-2.2.2
   name: keycloakx
   namespace: keycloak-dev
 spec:

--- a/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/prometheusrule.yaml
+++ b/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/prometheusrule.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
     app.kubernetes.io/version: 20.0.3
-    helm.sh/chart: keycloakx-2.2.1
+    helm.sh/chart: keycloakx-2.2.2
   name: keycloakx
   namespace: keycloak-dev
 spec:

--- a/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/service-headless.yaml
+++ b/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/service-headless.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloakx
     app.kubernetes.io/version: 20.0.3
-    helm.sh/chart: keycloakx-2.2.1
+    helm.sh/chart: keycloakx-2.2.2
   name: keycloakx-headless
   namespace: keycloak-dev
 spec:

--- a/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/service-http.yaml
+++ b/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/service-http.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
     app.kubernetes.io/version: 20.0.3
-    helm.sh/chart: keycloakx-2.2.1
+    helm.sh/chart: keycloakx-2.2.2
   name: keycloakx-http
   namespace: keycloak-dev
 spec:

--- a/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/serviceaccount.yaml
+++ b/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/serviceaccount.yaml
@@ -9,6 +9,6 @@ metadata:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
     app.kubernetes.io/version: 20.0.3
-    helm.sh/chart: keycloakx-2.2.1
+    helm.sh/chart: keycloakx-2.2.2
   name: keycloakx
   namespace: keycloak-dev

--- a/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/servicemonitor.yaml
+++ b/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
     app.kubernetes.io/version: 20.0.3
-    helm.sh/chart: keycloakx-2.2.1
+    helm.sh/chart: keycloakx-2.2.2
   name: keycloakx-keycloakx
   namespace: keycloak-dev
 spec:

--- a/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
     app.kubernetes.io/version: 20.0.3
-    helm.sh/chart: keycloakx-2.2.1
+    helm.sh/chart: keycloakx-2.2.2
   name: keycloakx
   namespace: keycloak-dev
 spec:


### PR DESCRIPTION
Requries at least Kubernetes v1.23 for HPA

## Checklist

- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

