### PR TITLE
Update the v21 update procedure notes with an Infinispan setup

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/upgrade-12.x-to-13.x.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade-12.x-to-13.x.adoc
@@ -2,6 +2,13 @@
 
 This guide describes the steps to perform an upgrade of the component from version v12 to v13.
 
+[NOTE]
+====
+It's higly recommended to scale the Keycloak statefulset to 1 during the upgrade.
+The Infinispan cluster can't handle the upgrade to v21.1.2 properly and fails with the error message `ERROR [org.jgroups.protocols.TCP] failed handling incoming message: java.lang.IllegalArgumentException: invalid magic number 256; needs to be in range [0..100]`.
+After the upgrade the Infinispan cluster works properly again.
+====
+
 == Changes
 
 * The component requires Kubernetes v1.23 or newer.


### PR DESCRIPTION
Keycloak clustering doesn't work during the upgrade and needs to be disabled during the upgrade.

## Checklist

- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
