### PR TITLE
Remove UseContainerSupport from JAVA_OPS 

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -199,7 +199,6 @@ parameters:
       extraEnv: |
         - name: JAVA_OPTS
           value: >-
-                    -XX:+UseContainerSupport
                     -XX:MaxRAMPercentage=50.0
                     -Djava.net.preferIPv4Stack=true
                     -Djava.awt.headless=true

--- a/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -61,8 +61,8 @@ spec:
             - name: FOO
               value: bar
             - name: JAVA_OPTS
-              value: -XX:+UseContainerSupport -XX:MaxRAMPercentage=50.0 -Djava.net.preferIPv4Stack=true
-                -Djava.awt.headless=true -Djgroups.dns.query=keycloakx-headless
+              value: -XX:MaxRAMPercentage=50.0 -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true
+                -Djgroups.dns.query=keycloakx-headless
             - name: KC_CACHE
               value: ispn
             - name: KC_CACHE_STACK

--- a/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -59,8 +59,8 @@ spec:
             - --http-enabled=true
           env:
             - name: JAVA_OPTS
-              value: -XX:+UseContainerSupport -XX:MaxRAMPercentage=50.0 -Djava.net.preferIPv4Stack=true
-                -Djava.awt.headless=true -Djgroups.dns.query=keycloakx-headless
+              value: -XX:MaxRAMPercentage=50.0 -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true
+                -Djgroups.dns.query=keycloakx-headless
             - name: KC_CACHE
               value: ispn
             - name: KC_CACHE_STACK

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -59,8 +59,8 @@ spec:
             - --http-enabled=true
           env:
             - name: JAVA_OPTS
-              value: -XX:+UseContainerSupport -XX:MaxRAMPercentage=50.0 -Djava.net.preferIPv4Stack=true
-                -Djava.awt.headless=true -Djgroups.dns.query=keycloakx-headless
+              value: -XX:MaxRAMPercentage=50.0 -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true
+                -Djgroups.dns.query=keycloakx-headless
             - name: KC_CACHE
               value: ispn
             - name: KC_CACHE_STACK

--- a/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -59,8 +59,8 @@ spec:
             - --http-enabled=true
           env:
             - name: JAVA_OPTS
-              value: -XX:+UseContainerSupport -XX:MaxRAMPercentage=50.0 -Djava.net.preferIPv4Stack=true
-                -Djava.awt.headless=true -Djgroups.dns.query=keycloakx-headless
+              value: -XX:MaxRAMPercentage=50.0 -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true
+                -Djgroups.dns.query=keycloakx-headless
             - name: KC_CACHE
               value: ispn
             - name: KC_CACHE_STACK


### PR DESCRIPTION
As it is default in OpenJDK17 since Keycloak v21.
    
Ref: https://github.com/keycloak/keycloak/blob/release/21.0/quarkus/container/Dockerfile#L20

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.
