### PR TITLE
Change relative path from /auth to / by default

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -65,6 +65,9 @@ parameters:
         version: 12.12.10
     # FQDN should be overwritten on the cluster level
     fqdn: keycloak.example.com
+    # Default path since Quarkus is "/" rather than "/auth"
+    # https://www.keycloak.org/migration/migrating-to-quarkus
+    relativePath: /
     # Disables dynamically resolving the hostname from request headers.
     hostnameStrict: ${keycloak:_hostname_strict:${keycloak:ingress:tls:termination}}
     # Namespace labels
@@ -184,6 +187,8 @@ parameters:
       image:
         repository: ${keycloak:images:keycloak:registry}/${keycloak:images:keycloak:repository}
         tag: ${keycloak:images:keycloak:tag}
+      http:
+        relativePath: ${keycloak:relativePath}
       replicas: ${keycloak:replicas}
       statefulsetLabels: ${keycloak:labels}
       resources: ${keycloak:resources}

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -116,6 +116,17 @@ Defines the FQDN the keycloak ingress or route object is configured.
 FQDN should be overwritten on the cluster level.
 
 
+== `relativePath`
+
+[horizontal]
+type:: string
+default:: `/`
+
+Defines the relative path of Keycloak.
+The default realtiv path of Keycloak has changed from `/auth` to `/` with the https://www.keycloak.org/migration/migrating-to-quarkus[migration to Quarkus].
+To preserve the legacy behavior of Wildfly set the relativePath to `/auth`.
+
+
 == `hostnameStrict`
 
 [horizontal]

--- a/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/servicemonitor.yaml
+++ b/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/servicemonitor.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   endpoints:
     - interval: 10s
-      path: /auth/metrics
+      path: /metrics
       port: http
       scrapeTimeout: 10s
   selector:

--- a/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -87,7 +87,7 @@ spec:
             - name: KC_HTTPS_CERTIFICATE_KEY_FILE
               value: /etc/x509/https/tls.key
             - name: KC_HTTP_RELATIVE_PATH
-              value: /auth
+              value: /
             - name: KC_METRICS_ENABLED
               value: 'true'
             - name: KC_PROXY
@@ -101,7 +101,7 @@ spec:
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
-              path: /auth/health/live
+              path: /health/live
               port: http
             initialDelaySeconds: 0
             timeoutSeconds: 5
@@ -115,7 +115,7 @@ spec:
               protocol: TCP
           readinessProbe:
             httpGet:
-              path: /auth/health/ready
+              path: /health/ready
               port: http
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -132,7 +132,7 @@ spec:
           startupProbe:
             failureThreshold: 60
             httpGet:
-              path: /auth/health
+              path: /health
               port: http
             initialDelaySeconds: 15
             periodSeconds: 5

--- a/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/servicemonitor.yaml
+++ b/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/servicemonitor.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   endpoints:
     - interval: 10s
-      path: /auth/metrics
+      path: /metrics
       port: http
       scrapeTimeout: 10s
   selector:

--- a/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -85,7 +85,7 @@ spec:
             - name: KC_HTTPS_CERTIFICATE_KEY_FILE
               value: /etc/x509/https/tls.key
             - name: KC_HTTP_RELATIVE_PATH
-              value: /auth
+              value: /
             - name: KC_METRICS_ENABLED
               value: 'true'
             - name: KC_PROXY
@@ -99,7 +99,7 @@ spec:
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
-              path: /auth/health/live
+              path: /health/live
               port: http
             initialDelaySeconds: 0
             timeoutSeconds: 5
@@ -113,7 +113,7 @@ spec:
               protocol: TCP
           readinessProbe:
             httpGet:
-              path: /auth/health/ready
+              path: /health/ready
               port: http
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -130,7 +130,7 @@ spec:
           startupProbe:
             failureThreshold: 60
             httpGet:
-              path: /auth/health
+              path: /health
               port: http
             initialDelaySeconds: 15
             periodSeconds: 5

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/servicemonitor.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/servicemonitor.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   endpoints:
     - interval: 10s
-      path: /auth/metrics
+      path: /metrics
       port: http
       scrapeTimeout: 10s
   selector:

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -85,7 +85,7 @@ spec:
             - name: KC_HTTPS_CERTIFICATE_KEY_FILE
               value: /etc/x509/https/tls.key
             - name: KC_HTTP_RELATIVE_PATH
-              value: /auth
+              value: /
             - name: KC_METRICS_ENABLED
               value: 'true'
             - name: KC_PROXY
@@ -99,7 +99,7 @@ spec:
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
-              path: /auth/health/live
+              path: /health/live
               port: http
             initialDelaySeconds: 0
             timeoutSeconds: 5
@@ -113,7 +113,7 @@ spec:
               protocol: TCP
           readinessProbe:
             httpGet:
-              path: /auth/health/ready
+              path: /health/ready
               port: http
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -130,7 +130,7 @@ spec:
           startupProbe:
             failureThreshold: 60
             httpGet:
-              path: /auth/health
+              path: /health
               port: http
             initialDelaySeconds: 15
             periodSeconds: 5

--- a/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/servicemonitor.yaml
+++ b/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/servicemonitor.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   endpoints:
     - interval: 10s
-      path: /auth/metrics
+      path: /metrics
       port: http
       scrapeTimeout: 10s
   selector:

--- a/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -85,7 +85,7 @@ spec:
             - name: KC_HTTPS_CERTIFICATE_KEY_FILE
               value: /etc/x509/https/tls.key
             - name: KC_HTTP_RELATIVE_PATH
-              value: /auth
+              value: /
             - name: KC_METRICS_ENABLED
               value: 'true'
             - name: KC_PROXY
@@ -99,7 +99,7 @@ spec:
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
-              path: /auth/health/live
+              path: /health/live
               port: http
             initialDelaySeconds: 0
             timeoutSeconds: 5
@@ -113,7 +113,7 @@ spec:
               protocol: TCP
           readinessProbe:
             httpGet:
-              path: /auth/health/ready
+              path: /health/ready
               port: http
             initialDelaySeconds: 10
             timeoutSeconds: 1
@@ -128,7 +128,7 @@ spec:
           startupProbe:
             failureThreshold: 60
             httpGet:
-              path: /auth/health
+              path: /health
               port: http
             initialDelaySeconds: 15
             periodSeconds: 5


### PR DESCRIPTION
The default realtiv path of Keycloak has changed from `/auth` to `/` with the https://www.keycloak.org/migration/migrating-to-quarkus[migration to Quarkus]. To preserve the legacy behavior of Wildfly set the relativePath to `/auth`.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

