### PR TITLE
Remove JAVA_OPTS java.net.preferIPv4Stack=true

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -200,7 +200,6 @@ parameters:
         - name: JAVA_OPTS
           value: >-
                     -XX:MaxRAMPercentage=50.0
-                    -Djava.net.preferIPv4Stack=true
                     -Djgroups.dns.query={{ include "keycloak.fullname" . }}-headless
                     ${keycloak:extraJavaOpts}
         - name: KC_HOSTNAME

--- a/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -61,7 +61,7 @@ spec:
             - name: FOO
               value: bar
             - name: JAVA_OPTS
-              value: -XX:MaxRAMPercentage=50.0 -Djava.net.preferIPv4Stack=true -Djgroups.dns.query=keycloakx-headless
+              value: -XX:MaxRAMPercentage=50.0 -Djgroups.dns.query=keycloakx-headless
             - name: KC_CACHE
               value: ispn
             - name: KC_CACHE_STACK

--- a/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -59,7 +59,7 @@ spec:
             - --http-enabled=true
           env:
             - name: JAVA_OPTS
-              value: -XX:MaxRAMPercentage=50.0 -Djava.net.preferIPv4Stack=true -Djgroups.dns.query=keycloakx-headless
+              value: -XX:MaxRAMPercentage=50.0 -Djgroups.dns.query=keycloakx-headless
             - name: KC_CACHE
               value: ispn
             - name: KC_CACHE_STACK

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -59,7 +59,7 @@ spec:
             - --http-enabled=true
           env:
             - name: JAVA_OPTS
-              value: -XX:MaxRAMPercentage=50.0 -Djava.net.preferIPv4Stack=true -Djgroups.dns.query=keycloakx-headless
+              value: -XX:MaxRAMPercentage=50.0 -Djgroups.dns.query=keycloakx-headless
             - name: KC_CACHE
               value: ispn
             - name: KC_CACHE_STACK

--- a/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -59,7 +59,7 @@ spec:
             - --http-enabled=true
           env:
             - name: JAVA_OPTS
-              value: -XX:MaxRAMPercentage=50.0 -Djava.net.preferIPv4Stack=true -Djgroups.dns.query=keycloakx-headless
+              value: -XX:MaxRAMPercentage=50.0 -Djgroups.dns.query=keycloakx-headless
             - name: KC_CACHE
               value: ispn
             - name: KC_CACHE_STACK


### PR DESCRIPTION
Keycloak v22 ships with [IPv6 enabled](https://github.com/keycloak/keycloak/issues/15003) by default.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
