### PR TITLE
Change POSTGRES_DB to POSTGRES_DATABASE

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -303,7 +303,7 @@ parameters:
         existingSecret: ${keycloak:database:secretname}
       primary:
         podAnnotations:
-          k8up.io/backupcommand: sh -c 'PGDATABASE="$POSTGRES_DB" PGUSER="$POSTGRES_USER" PGPASSWORD="$POSTGRES_PASSWORD" pg_dump --clean'
+          k8up.io/backupcommand: sh -c 'PGDATABASE="$POSTGRES_DATABASE" PGUSER="$POSTGRES_USER" PGPASSWORD="$POSTGRES_PASSWORD" pg_dump --clean'
           k8up.io/file-extension: .sql
         labels: ${keycloak:labels}
         containerSecurityContext:

--- a/docs/modules/ROOT/pages/how-tos/change-passwords.adoc
+++ b/docs/modules/ROOT/pages/how-tos/change-passwords.adoc
@@ -80,7 +80,7 @@ vault kv patch "${parent}/${instance}" db-password="${db_pass}"
 namespace=syn-${instance}
 
 kubectl -n ${namespace} exec -it keycloak-postgresql-0 -c keycloak-postgresql -- sh -c \
-'PGDATABASE="$POSTGRES_DB" PGUSER="$POSTGRES_USER" PGPASSWORD="'${old_pass}'" '\
+'PGDATABASE="$POSTGRES_DATABASE" PGUSER="$POSTGRES_USER" PGPASSWORD="'${old_pass}'" '\
 'psql -c "ALTER USER keycloak WITH PASSWORD '${db_pass}';"'
 ----
 +

--- a/docs/modules/ROOT/pages/how-tos/db-tls.adoc
+++ b/docs/modules/ROOT/pages/how-tos/db-tls.adoc
@@ -87,7 +87,7 @@ parameters:
 ----
 namespace=syn-keycloak
 kubectl exec -it -n ${namespace} keycloak-postgresql-0 -c keycloak-postgresql -- sh -c \
-'PGDATABASE="$POSTGRES_DB" PGUSER="$POSTGRES_USER" PGPASSWORD="$POSTGRES_PASSWORD" '\
+'PGDATABASE="$POSTGRES_DATABASE" PGUSER="$POSTGRES_USER" PGPASSWORD="$POSTGRES_PASSWORD" '\
 'psql -c "SELECT datname, usename, ssl, client_addr FROM pg_stat_ssl JOIN pg_stat_activity ON pg_stat_ssl.pid = pg_stat_activity.pid;"'
 ----
 +

--- a/docs/modules/ROOT/pages/how-tos/restore.adoc
+++ b/docs/modules/ROOT/pages/how-tos/restore.adoc
@@ -112,7 +112,7 @@ export POD=keycloak-postgresql-0
 
 restic dump "${SNAPSHOT_ID}" /$NAMESPACE-keycloak-postgresql.sql \
   | kubectl -n $NAMESPACE exec -i $POD \
-  -- sh -c 'PGPASSWORD="${POSTGRES_PASSWORD}" psql --set ON_ERROR_STOP=on -U "${POSTGRES_USER}" ${POSTGRES_DB}'
+  -- sh -c 'PGPASSWORD="${POSTGRES_PASSWORD}" psql --set ON_ERROR_STOP=on -U "${POSTGRES_USER}" ${POSTGRES_DATABASE}'
 ----
 
 . Re-enable ArgoCD auto sync and scale up Keycloak

--- a/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/postgresql/templates/primary/statefulset.yaml
+++ b/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/postgresql/templates/primary/statefulset.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        k8up.io/backupcommand: sh -c 'PGDATABASE="$POSTGRES_DB" PGUSER="$POSTGRES_USER"
+        k8up.io/backupcommand: sh -c 'PGDATABASE="$POSTGRES_DATABASE" PGUSER="$POSTGRES_USER"
           PGPASSWORD="$POSTGRES_PASSWORD" pg_dump --clean'
         k8up.io/file-extension: .sql
       labels:

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/postgresql/templates/primary/statefulset.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/postgresql/templates/primary/statefulset.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        k8up.io/backupcommand: sh -c 'PGDATABASE="$POSTGRES_DB" PGUSER="$POSTGRES_USER"
+        k8up.io/backupcommand: sh -c 'PGDATABASE="$POSTGRES_DATABASE" PGUSER="$POSTGRES_USER"
           PGPASSWORD="$POSTGRES_PASSWORD" pg_dump --clean'
         k8up.io/file-extension: .sql
       labels:


### PR DESCRIPTION
Bitnami has changes the POSTGRES_DB variable to POSTGRES_DATABASE. This had no influence on the functionality, but is just wrong now.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
