### PR TITLE
Upgrade to Keycloak v25

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -43,7 +43,7 @@ parameters:
       keycloak:
         registry: quay.io
         repository: keycloak/keycloak
-        tag: 24.0.5
+        tag: 25.0.6
       busybox:
         registry: docker.io
         repository: busybox
@@ -59,7 +59,7 @@ parameters:
     charts:
       keycloakx:
         source: https://codecentric.github.io/helm-charts
-        version: v2.3.0
+        version: 2.5.1
       postgresql:
         source: https://charts.bitnami.com/bitnami
         version: 12.12.10
@@ -189,6 +189,8 @@ parameters:
         tag: ${keycloak:images:keycloak:tag}
       http:
         relativePath: ${keycloak:relativePath}
+        # Required because the Keycloak management port is HTTPS by default but the keycloakx helm chart has a default to HTTP
+        internalScheme: HTTPS
       replicas: ${keycloak:replicas}
       statefulsetLabels: ${keycloak:labels}
       resources: ${keycloak:resources}
@@ -197,7 +199,6 @@ parameters:
       # See https://www.keycloak.org/server/all-config
       args:
         - start
-        - --http-enabled=true # Helm chart requires it currently
 
       # extraEnv *MUST* be a string, as it's fed through a templating
       # function.
@@ -286,10 +287,6 @@ parameters:
         image:
           repository: ${keycloak:images:busybox:registry}/${keycloak:images:busybox:repository}
           tag: ${keycloak:images:busybox:tag}
-      proxy:
-        enabled: 'true'
-        mode: ${keycloak:ingress:tls:termination}
-
       metrics:
         enabled: ${keycloak:monitoring:enabled}
       database:

--- a/docs/modules/ROOT/pages/how-tos/upgrade-17.x-to-18.x.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade-17.x-to-18.x.adoc
@@ -1,0 +1,45 @@
+= Upgrade from v17 to v18
+
+This guide describes the steps to perform an upgrade of the component from version v17 to v18.
+
+== Breaking Changes
+
+* The component doesn't work with an older Keycloak version than v25.
+
+== Changes
+
+* The component requires Kubernetes v1.25 or newer.
+* Keycloak version is v25.0.6 by default.
+
+== Parameter changes
+
+* The reverse proxy mode is no longer linked to the ingress mode. Source IPs taken from the `Forwarded header` as per RFC7239. To use `X-Forwarded-*` headers see below. You also may consult the  https://www.keycloak.org/server/reverseproxy#_configure_the_reverse_proxy_headers[Keycloak documentation].
+
+== Step-by-step guide
+
+When upgrading the component, the following actions are required if the built-in database is used:
+
+. If your setup requires `X-Forwarded-*` headers rather than `Forwarded header` as per RFC7239:
++
+[source,bash]
+----
+parameters:
+  keycloak:
+    helm_values:
+      proxy:
+        mode: xforwarded
+----
+
+. Do a backup of the built-in database.
++
+[source,bash]
+----
+instance=keycloak
+namespace=syn-${instance}
+
+kubectl -n "${namespace}" exec -ti keycloak-postgresql-0 -c postgresql -- sh -c 'PGDATABASE="$POSTGRES_DATABASE" PGUSER="$POSTGRES_USER" PGPASSWORD="$POSTGRES_PASSWORD" pg_dump --clean' > keycloak-postgresql-$(date +%F-%H-%M-%S).sql
+----
+
+. Apply the parameter changes.
+
+. Compile and push the cluster catalog.

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -29,6 +29,7 @@
 * xref:how-tos/upgrade-14.x-to-15.x.adoc[Upgrade 14.x to 15.x]
 * xref:how-tos/upgrade-15.x-to-16.x.adoc[Upgrade 15.x to 16.x]
 * xref:how-tos/upgrade-16.x-to-17.x.adoc[Upgrade 16.x to 17.x]
+* xref:how-tos/upgrade-17.x-to-18.x.adoc[Upgrade 17.x to 18.x]
 * xref:how-tos/openshift-4.adoc[Install on OpenShift 4]
 * xref:how-tos/pin-versions.adoc[Pin versions]
 

--- a/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/ingress.yaml
+++ b/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/ingress.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: builtin
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx
   namespace: syn-builtin
 spec:

--- a/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/networkpolicy.yaml
+++ b/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/networkpolicy.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: keycloakx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloakx
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx
   namespace: syn-builtin
 spec:

--- a/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/prometheusrule.yaml
+++ b/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/prometheusrule.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/instance: builtin
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx
   namespace: syn-builtin
 spec:

--- a/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/service-headless.yaml
+++ b/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/service-headless.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/instance: keycloakx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloakx
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx-headless
   namespace: syn-builtin
 spec:

--- a/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/service-http.yaml
+++ b/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/service-http.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/instance: builtin
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx-http
   namespace: syn-builtin
 spec:

--- a/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/serviceaccount.yaml
+++ b/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: builtin
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx
   namespace: syn-builtin

--- a/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/servicemonitor.yaml
+++ b/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/servicemonitor.yaml
@@ -6,15 +6,16 @@ metadata:
     app.kubernetes.io/instance: builtin
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx-keycloakx
   namespace: syn-builtin
 spec:
   endpoints:
     - interval: 10s
       path: /metrics
-      port: http
+      port: http-internal
+      scheme: https
       scrapeTimeout: 10s
   selector:
     matchLabels:

--- a/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/instance: builtin
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx
   namespace: syn-builtin
 spec:
@@ -56,7 +56,6 @@ spec:
       containers:
         - args:
             - start
-            - --http-enabled=true
           env:
             - name: FOO
               value: bar
@@ -86,23 +85,26 @@ spec:
               value: /etc/x509/https/tls.crt
             - name: KC_HTTPS_CERTIFICATE_KEY_FILE
               value: /etc/x509/https/tls.key
+            - name: KC_HTTP_ENABLED
+              value: 'true'
             - name: KC_HTTP_RELATIVE_PATH
               value: /
             - name: KC_METRICS_ENABLED
               value: 'true'
-            - name: KC_PROXY
-              value: reencrypt
+            - name: KC_PROXY_HEADERS
+              value: forwarded
           envFrom:
             - secretRef:
                 name: keycloak-admin-user
             - secretRef:
                 name: keycloak-postgresql
-          image: quay.io/keycloak/keycloak:24.0.5
+          image: quay.io/keycloak/keycloak:25.0.6
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
               path: /health/live
-              port: http
+              port: http-internal
+              scheme: HTTPS
             initialDelaySeconds: 0
             timeoutSeconds: 5
           name: keycloak
@@ -110,13 +112,17 @@ spec:
             - containerPort: 8080
               name: http
               protocol: TCP
+            - containerPort: 9000
+              name: http-internal
+              protocol: TCP
             - containerPort: 8443
               name: https
               protocol: TCP
           readinessProbe:
             httpGet:
               path: /health/ready
-              port: http
+              port: http-internal
+              scheme: HTTPS
             initialDelaySeconds: 10
             timeoutSeconds: 1
           resources:
@@ -133,7 +139,8 @@ spec:
             failureThreshold: 60
             httpGet:
               path: /health
-              port: http
+              port: http-internal
+              scheme: HTTPS
             initialDelaySeconds: 15
             periodSeconds: 5
             timeoutSeconds: 1

--- a/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/ingress.yaml
+++ b/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/ingress.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/instance: external
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx
   namespace: syn-external
 spec:

--- a/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/networkpolicy.yaml
+++ b/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/networkpolicy.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: keycloakx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloakx
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx
   namespace: syn-external
 spec:

--- a/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/prometheusrule.yaml
+++ b/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/prometheusrule.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/instance: external
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx
   namespace: syn-external
 spec:

--- a/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/service-headless.yaml
+++ b/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/service-headless.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/instance: keycloakx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloakx
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx-headless
   namespace: syn-external
 spec:

--- a/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/service-http.yaml
+++ b/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/service-http.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/instance: external
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx-http
   namespace: syn-external
 spec:

--- a/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/serviceaccount.yaml
+++ b/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: external
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx
   namespace: syn-external

--- a/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/servicemonitor.yaml
+++ b/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/servicemonitor.yaml
@@ -6,15 +6,16 @@ metadata:
     app.kubernetes.io/instance: external
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx-keycloakx
   namespace: syn-external
 spec:
   endpoints:
     - interval: 10s
       path: /metrics
-      port: http
+      port: http-internal
+      scheme: https
       scrapeTimeout: 10s
   selector:
     matchLabels:

--- a/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/external/external/external/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/instance: external
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx
   namespace: syn-external
 spec:
@@ -56,7 +56,6 @@ spec:
       containers:
         - args:
             - start
-            - --http-enabled=true
           env:
             - name: JAVA_OPTS
               value: -XX:MaxRAMPercentage=50.0 -Djgroups.dns.query=keycloakx-headless
@@ -84,23 +83,26 @@ spec:
               value: /etc/x509/https/tls.crt
             - name: KC_HTTPS_CERTIFICATE_KEY_FILE
               value: /etc/x509/https/tls.key
+            - name: KC_HTTP_ENABLED
+              value: 'true'
             - name: KC_HTTP_RELATIVE_PATH
               value: /
             - name: KC_METRICS_ENABLED
               value: 'true'
-            - name: KC_PROXY
-              value: passthrough
+            - name: KC_PROXY_HEADERS
+              value: forwarded
           envFrom:
             - secretRef:
                 name: keycloak-admin-user
             - secretRef:
                 name: keycloak-postgresql
-          image: quay.io/keycloak/keycloak:24.0.5
+          image: quay.io/keycloak/keycloak:25.0.6
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
               path: /health/live
-              port: http
+              port: http-internal
+              scheme: HTTPS
             initialDelaySeconds: 0
             timeoutSeconds: 5
           name: keycloak
@@ -108,13 +110,17 @@ spec:
             - containerPort: 8080
               name: http
               protocol: TCP
+            - containerPort: 9000
+              name: http-internal
+              protocol: TCP
             - containerPort: 8443
               name: https
               protocol: TCP
           readinessProbe:
             httpGet:
               path: /health/ready
-              port: http
+              port: http-internal
+              scheme: HTTPS
             initialDelaySeconds: 10
             timeoutSeconds: 1
           resources:
@@ -131,7 +137,8 @@ spec:
             failureThreshold: 60
             httpGet:
               path: /health
-              port: http
+              port: http-internal
+              scheme: HTTPS
             initialDelaySeconds: 15
             periodSeconds: 5
             timeoutSeconds: 1

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/ingress.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/ingress.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: openshift-postgres
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx
   namespace: syn-openshift-postgres
 spec:

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/networkpolicy.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/networkpolicy.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: keycloakx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloakx
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx
   namespace: syn-openshift-postgres
 spec:

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/prometheusrule.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/prometheusrule.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/instance: openshift-postgres
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx
   namespace: syn-openshift-postgres
 spec:

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/service-headless.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/service-headless.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/instance: keycloakx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloakx
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx-headless
   namespace: syn-openshift-postgres
 spec:

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/service-http.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/service-http.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/instance: openshift-postgres
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx-http
   namespace: syn-openshift-postgres
 spec:

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/serviceaccount.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: openshift-postgres
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx
   namespace: syn-openshift-postgres

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/servicemonitor.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/servicemonitor.yaml
@@ -6,15 +6,16 @@ metadata:
     app.kubernetes.io/instance: openshift-postgres
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx-keycloakx
   namespace: syn-openshift-postgres
 spec:
   endpoints:
     - interval: 10s
       path: /metrics
-      port: http
+      port: http-internal
+      scheme: https
       scrapeTimeout: 10s
   selector:
     matchLabels:

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/instance: openshift-postgres
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx
   namespace: syn-openshift-postgres
 spec:
@@ -56,7 +56,6 @@ spec:
       containers:
         - args:
             - start
-            - --http-enabled=true
           env:
             - name: JAVA_OPTS
               value: -XX:MaxRAMPercentage=50.0 -Djgroups.dns.query=keycloakx-headless
@@ -84,23 +83,26 @@ spec:
               value: /etc/x509/https/tls.crt
             - name: KC_HTTPS_CERTIFICATE_KEY_FILE
               value: /etc/x509/https/tls.key
+            - name: KC_HTTP_ENABLED
+              value: 'true'
             - name: KC_HTTP_RELATIVE_PATH
               value: /
             - name: KC_METRICS_ENABLED
               value: 'true'
-            - name: KC_PROXY
-              value: reencrypt
+            - name: KC_PROXY_HEADERS
+              value: forwarded
           envFrom:
             - secretRef:
                 name: keycloak-admin-user
             - secretRef:
                 name: keycloak-postgresql
-          image: quay.io/keycloak/keycloak:24.0.5
+          image: quay.io/keycloak/keycloak:25.0.6
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
               path: /health/live
-              port: http
+              port: http-internal
+              scheme: HTTPS
             initialDelaySeconds: 0
             timeoutSeconds: 5
           name: keycloak
@@ -108,13 +110,17 @@ spec:
             - containerPort: 8080
               name: http
               protocol: TCP
+            - containerPort: 9000
+              name: http-internal
+              protocol: TCP
             - containerPort: 8443
               name: https
               protocol: TCP
           readinessProbe:
             httpGet:
               path: /health/ready
-              port: http
+              port: http-internal
+              scheme: HTTPS
             initialDelaySeconds: 10
             timeoutSeconds: 1
           resources:
@@ -131,7 +137,8 @@ spec:
             failureThreshold: 60
             httpGet:
               path: /health
-              port: http
+              port: http-internal
+              scheme: HTTPS
             initialDelaySeconds: 15
             periodSeconds: 5
             timeoutSeconds: 1

--- a/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/ingress.yaml
+++ b/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/ingress.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: openshift
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx
   namespace: keycloak-dev
 spec:

--- a/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/networkpolicy.yaml
+++ b/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/networkpolicy.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: keycloakx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloakx
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx
   namespace: keycloak-dev
 spec:

--- a/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/prometheusrule.yaml
+++ b/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/prometheusrule.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/instance: openshift
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx
   namespace: keycloak-dev
 spec:

--- a/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/service-headless.yaml
+++ b/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/service-headless.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/instance: keycloakx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloakx
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx-headless
   namespace: keycloak-dev
 spec:

--- a/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/service-http.yaml
+++ b/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/service-http.yaml
@@ -8,8 +8,8 @@ metadata:
     app.kubernetes.io/instance: openshift
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx-http
   namespace: keycloak-dev
 spec:

--- a/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/serviceaccount.yaml
+++ b/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: openshift
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx
   namespace: keycloak-dev

--- a/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/servicemonitor.yaml
+++ b/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/servicemonitor.yaml
@@ -6,15 +6,16 @@ metadata:
     app.kubernetes.io/instance: openshift
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx-keycloakx
   namespace: keycloak-dev
 spec:
   endpoints:
     - interval: 10s
       path: /metrics
-      port: http
+      port: http-internal
+      scheme: https
       scrapeTimeout: 10s
   selector:
     matchLabels:

--- a/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
+++ b/tests/golden/openshift/openshift/openshift/01_keycloak_helmchart/keycloakx/templates/statefulset.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/instance: openshift
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 24.0.5
-    helm.sh/chart: keycloakx-2.3.0
+    app.kubernetes.io/version: 25.0.6
+    helm.sh/chart: keycloakx-2.5.1
   name: keycloakx
   namespace: keycloak-dev
 spec:
@@ -56,7 +56,6 @@ spec:
       containers:
         - args:
             - start
-            - --http-enabled=true
           env:
             - name: JAVA_OPTS
               value: -XX:MaxRAMPercentage=50.0 -Djgroups.dns.query=keycloakx-headless
@@ -84,23 +83,26 @@ spec:
               value: /etc/x509/https/tls.crt
             - name: KC_HTTPS_CERTIFICATE_KEY_FILE
               value: /etc/x509/https/tls.key
+            - name: KC_HTTP_ENABLED
+              value: 'true'
             - name: KC_HTTP_RELATIVE_PATH
               value: /
             - name: KC_METRICS_ENABLED
               value: 'true'
-            - name: KC_PROXY
-              value: reencrypt
+            - name: KC_PROXY_HEADERS
+              value: forwarded
           envFrom:
             - secretRef:
                 name: keycloak-admin-user
             - secretRef:
                 name: keycloak-postgresql
-          image: quay.io/keycloak/keycloak:24.0.5
+          image: quay.io/keycloak/keycloak:25.0.6
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
               path: /health/live
-              port: http
+              port: http-internal
+              scheme: HTTPS
             initialDelaySeconds: 0
             timeoutSeconds: 5
           name: keycloak
@@ -108,13 +110,17 @@ spec:
             - containerPort: 8080
               name: http
               protocol: TCP
+            - containerPort: 9000
+              name: http-internal
+              protocol: TCP
             - containerPort: 8443
               name: https
               protocol: TCP
           readinessProbe:
             httpGet:
               path: /health/ready
-              port: http
+              port: http-internal
+              scheme: HTTPS
             initialDelaySeconds: 10
             timeoutSeconds: 1
           resources:
@@ -129,7 +135,8 @@ spec:
             failureThreshold: 60
             httpGet:
               path: /health
-              port: http
+              port: http-internal
+              scheme: HTTPS
             initialDelaySeconds: 15
             periodSeconds: 5
             timeoutSeconds: 1


### PR DESCRIPTION
* Rise the minimum Keycloak version to v25.0.6
* Keycloakx Helm Chart to 2.5.1
* Switch the monitoring check from HTTP to HTTPS because the default managment port has HTTPS enabled
* Remove the duplicate --http-enabled parameter as it is already enabled using the environment variable KC_HTTP_ENABLED from the helm chart
* Remove the proxy config and use the default from the helm chart

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

