### PR TITLE
Switch to `bitnamilegacy` images for builtin Postgresql

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -52,11 +52,11 @@ parameters:
         tag: 1.32
       postgresql:
         registry: docker.io
-        repository: bitnami/postgresql
+        repository: bitnamilegacy/postgresql
         tag: 15.10.0-debian-12-r2
       bitnamishell:
         registry: docker.io
-        repository: bitnami/os-shell
+        repository: bitnamilegacy/os-shell
         tag: 12-debian-12-r49
     charts:
       keycloakx:

--- a/postprocess/postgresql.jsonnet
+++ b/postprocess/postgresql.jsonnet
@@ -13,10 +13,67 @@ local files_in_dir = std.native('list_dir')(dir_path, true);
 /* Remove file_extension from file list */
 local files = [ std.strReplace(file, file_extension, '') for file in files_in_dir ];
 
+local bitnami_ready =
+  '[ -f /opt/bitnami/postgresql/tmp/.initialized ] || [ -f /bitnami/postgresql/.initialized ]\n';
+
+// NOTE(sg): The Helm chart has custom logic to inject the `bitnami_ready`
+// string in the postgres container's readiness probe when it's rendered with
+// an image that contains exactly `bitnami/`. We mimic the Helm chart's
+// behavior for images that contain `bitnamilegacy/` here since those still
+// are bitnami images and will have the bitnami special readiness indication
+// file.
+local patchReadinessProbe(obj) =
+  if std.startsWith(params.images.postgresql.repository, 'bitnamilegacy/')
+     && obj.kind == 'StatefulSet'
+     && obj.metadata.name == 'keycloak-postgresql'
+  then
+    local containers = obj.spec.template.spec.containers;
+    assert
+      std.length(containers) == 1 :
+      'Expected builtin postgres statefulset to have a single container';
+    // extract the readiness probe command
+    local rcommand = containers[0].readinessProbe.exec.command;
+    // extract the sh -c -e prefix
+    local shell = rcommand[0:std.length(rcommand) - 1];
+    assert
+      shell[0] == '/bin/sh' :
+      'expected readiness command to start with\n    /bin/sh';
+    // patch the command string with a second line checking for the bitnami
+    // initialized file.
+    local cmd = rcommand[std.length(rcommand) - 1];
+    assert
+      std.startsWith(cmd, 'exec pg_isready') :
+      'expected readiness probe to use `exec pg_isready`';
+    local patched_cmd = [ cmd + bitnami_ready ];
+    obj {
+      spec+: {
+        template+: {
+          spec+: {
+            containers: [
+              containers[0] {
+                readinessProbe+: {
+                  exec: {
+                    // set the patched command
+                    command: shell + patched_cmd,
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+    }
+  else
+    obj;
+
 {
   [file]:
     if params.postgresql_helm_values.enabled
-    then com.yaml_load(std.extVar('output_path') + '/' + file + file_extension)
-    else []
+    then
+      patchReadinessProbe(
+        com.yaml_load(std.extVar('output_path') + '/' + file + file_extension)
+      )
+    else
+      []
   for file in files
 }

--- a/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/postgresql/templates/primary/statefulset.yaml
+++ b/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/postgresql/templates/primary/statefulset.yaml
@@ -92,7 +92,7 @@ spec:
               value: error
             - name: POSTGRESQL_SHARED_PRELOAD_LIBRARIES
               value: pgaudit
-          image: docker.io/bitnami/postgresql:15.10.0-debian-12-r2
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             exec:
@@ -162,7 +162,7 @@ spec:
               cp /tmp/certs/* /opt/bitnami/postgresql/certs/
               chown -R 1001:1001 /opt/bitnami/postgresql/certs/
               chmod 600 /opt/bitnami/postgresql/certs/tls.key
-          image: docker.io/bitnami/os-shell:12-debian-12-r49
+          image: docker.io/bitnamilegacy/os-shell:12-debian-12-r49
           imagePullPolicy: IfNotPresent
           name: init-chmod-data
           resources:

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/postgresql/templates/primary/statefulset.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/postgresql/templates/primary/statefulset.yaml
@@ -92,7 +92,7 @@ spec:
               value: error
             - name: POSTGRESQL_SHARED_PRELOAD_LIBRARIES
               value: pgaudit
-          image: docker.io/bitnami/postgresql:15.10.0-debian-12-r2
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             exec:
@@ -152,7 +152,7 @@ spec:
             - |
               cp /tmp/certs/* /opt/bitnami/postgresql/certs/
               chmod 600 /opt/bitnami/postgresql/certs/tls.key
-          image: docker.io/bitnami/os-shell:12-debian-12-r49
+          image: docker.io/bitnamilegacy/os-shell:12-debian-12-r49
           imagePullPolicy: IfNotPresent
           name: copy-certs
           resources:


### PR DESCRIPTION
The Bitnami Postgresql Helm chart has a custom readiness probe for the Bitnami Postgresql image. However, that custom logic doesn't recognize the `bitnamilegacy/postgresql` image as a Bitnami image, so we also update the postprocessing filter to replicate the custom readiness probe.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
