### PR TITLE
fix: replace Bitnami images with open Soldevelo equivalents

### DIFF
--- a/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/postgresql/templates/primary/statefulset.yaml
+++ b/tests/golden/builtin/builtin/builtin/01_keycloak_helmchart/postgresql/templates/primary/statefulset.yaml
@@ -162,7 +162,7 @@ spec:
               cp /tmp/certs/* /opt/bitnami/postgresql/certs/
               chown -R 1001:1001 /opt/bitnami/postgresql/certs/
               chmod 600 /opt/bitnami/postgresql/certs/tls.key
-          image: docker.io/bitnamilegacy/os-shell:12-debian-12-r49
+          image: docker.io/soldevelo/os-shell:12-debian-12-r3
           imagePullPolicy: IfNotPresent
           name: init-chmod-data
           resources:

--- a/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/postgresql/templates/primary/statefulset.yaml
+++ b/tests/golden/openshift-postgres/openshift-postgres/openshift-postgres/01_keycloak_helmchart/postgresql/templates/primary/statefulset.yaml
@@ -152,7 +152,7 @@ spec:
             - |
               cp /tmp/certs/* /opt/bitnami/postgresql/certs/
               chmod 600 /opt/bitnami/postgresql/certs/tls.key
-          image: docker.io/bitnamilegacy/os-shell:12-debian-12-r49
+          image: docker.io/soldevelo/os-shell:12-debian-12-r3
           imagePullPolicy: IfNotPresent
           name: copy-certs
           resources:


### PR DESCRIPTION
## Fix: replace restricted Bitnami images

Since **August 28, 2025**, Bitnami distributes most container images only through paid VMware Tanzu subscriptions. Pulling them without a valid subscription may fail silently or return stale image layers, which is a supply-chain reliability concern.

This PR replaces every affected reference with the corresponding image from [SolDevelo/containers](https://github.com/SolDevelo/containers) - a community fork of `bitnami/containers` that publishes identical, freely accessible images to Docker Hub under the `soldevelo/` namespace.

No configuration changes beyond the image tag itself are required.

## Replaced references

- `bitnamilegacy/os-shell:12-debian-12-r49` → [`soldevelo/os-shell:12-debian-12-r3`](https://hub.docker.com/r/soldevelo/os-shell)